### PR TITLE
[feat] Implement OP_SUB opcode

### DIFF
--- a/src/compiler.cairo
+++ b/src/compiler.cairo
@@ -20,7 +20,9 @@ pub impl CompilerTraitImpl of CompilerTrait {
         // Add the opcodes to the dict
         opcodes.insert('OP_0', Opcode::OP_0);
         opcodes.insert('OP_1', Opcode::OP_1);
+        opcodes.insert('OP_2', Opcode::OP_2);
         opcodes.insert('OP_ADD', Opcode::OP_ADD);
+        opcodes.insert('OP_SUB', Opcode::OP_SUB);
         Compiler { opcodes }
     }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -9,5 +9,6 @@ pub mod opcodes {
 }
 pub mod engine;
 pub mod stack;
+pub mod utils;
 
 mod main;

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -181,8 +181,6 @@ pub mod Opcode {
         // TODO: Error handling
         let a = engine.dstack.pop_int();
         let b = engine.dstack.pop_int();
-        let felt: felt252 = b.into() - a.into();
-        println!("{}", felt);
         engine.dstack.push_int(b - a);
     }
 

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -2,9 +2,7 @@ pub mod Opcode {
     pub const OP_0: u8 = 0;
     pub const OP_1: u8 = 81;
     pub const OP_2: u8 = 82;
-    pub const OP_ADD: u8 = 147;
     pub const OP_TRUE: u8 = 81;
-    pub const OP_2: u8 = 82;
     pub const OP_3: u8 = 83;
     pub const OP_4: u8 = 84;
     pub const OP_5: u8 = 85;
@@ -212,7 +210,7 @@ pub mod Opcode {
         let b = engine.dstack.pop_int();
         engine.dstack.push_int(a + b);
     }
-    
+
     fn opcode_sub(ref engine: Engine) {
         // TODO: Error handling
         let a = engine.dstack.pop_int();

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -181,6 +181,8 @@ pub mod Opcode {
         // TODO: Error handling
         let a = engine.dstack.pop_int();
         let b = engine.dstack.pop_int();
+        let felt: felt252 = b.into() - a.into();
+        println!("{}", felt);
         engine.dstack.push_int(b - a);
     }
 

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -1,8 +1,8 @@
 pub mod Opcode {
     pub const OP_0: u8 = 0;
     pub const OP_1: u8 = 81;
-    pub const OP_2: u8 = 82;
     pub const OP_TRUE: u8 = 81;
+    pub const OP_2: u8 = 82;
     pub const OP_3: u8 = 83;
     pub const OP_4: u8 = 84;
     pub const OP_5: u8 = 85;

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -1,7 +1,9 @@
 pub mod Opcode {
     pub const OP_0: u8 = 0;
     pub const OP_1: u8 = 81;
+    pub const OP_2: u8 = 82;
     pub const OP_ADD: u8 = 147;
+    pub const OP_SUB: u8 = 148;
 
     use shinigami::engine::Engine;
     use shinigami::stack::ScriptStackTrait;
@@ -89,7 +91,7 @@ pub mod Opcode {
             79 => not_implemented(ref engine),
             80 => not_implemented(ref engine),
             81 => opcode_n(1, ref engine),
-            82 => not_implemented(ref engine),
+            82 => opcode_n(2, ref engine),
             83 => not_implemented(ref engine),
             84 => not_implemented(ref engine),
             85 => not_implemented(ref engine),
@@ -155,6 +157,7 @@ pub mod Opcode {
             145 => not_implemented(ref engine),
             146 => not_implemented(ref engine),
             147 => opcode_add(ref engine),
+            148 => opcode_sub(ref engine),
             _ => not_implemented(ref engine)
         }
     }
@@ -172,6 +175,13 @@ pub mod Opcode {
         let a = engine.dstack.pop_int();
         let b = engine.dstack.pop_int();
         engine.dstack.push_int(a + b);
+    }
+
+    fn opcode_sub(ref engine: Engine) {
+        // TODO: Error handling
+        let a = engine.dstack.pop_int();
+        let b = engine.dstack.pop_int();
+        engine.dstack.push_int(b - a);
     }
 
     fn not_implemented(ref engine: Engine) {

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -64,7 +64,7 @@ fn test_op_sub() {
     assert!(res, "Execution of run failed");
 
     let dstack = engine.get_dstack();
-    // assert_eq!(dstack.len(), 1, "Stack length is not 1");
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
     let expected_stack = array!["\0\0\0\0\0\0\0\x00"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
@@ -79,7 +79,7 @@ fn test_op_sub() {
     assert!(res, "Execution of run failed");
 
     let dstack = engine.get_dstack();
-    // assert_eq!(dstack.len(), 1, "Stack length is not 1");
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
     let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
@@ -99,8 +99,10 @@ fn test_op_sub_panic() {
     assert!(res, "Execution of run failed");
 
     let dstack = engine.get_dstack();
-    // assert_eq!(dstack.len(), 1, "Stack length is not 1");
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array![
+        "\0\0\0\0\0\0\0\x03618502788666131213697322783095070105623107215331596699973092056135872020480"
+    ];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -53,6 +53,65 @@ fn test_op_add() {
 }
 
 #[test]
+fn test_op_sub() {
+    let program = "OP_1 OP_1 OP_SUB";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of run failed");
+
+    let dstack = engine.get_dstack();
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\x00"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+
+    let program = "OP_2 OP_1 OP_SUB";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of run failed");
+
+    let dstack = engine.get_dstack();
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+}
+
+#[should_panic(expected: ('Option::unwrap failed.',))]
+#[test]
+fn test_op_sub_panic() {
+    let program = "OP_1 OP_2 OP_SUB";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of run failed");
+
+    let dstack = engine.get_dstack();
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array![
+        "\0\0\0\0\0\0\0\x03618502788666131213697322783095070105623107215331596699973092056135872020480"
+    ];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+// ByteArray added to the stack (result of 1 - 2)
+// [DEBUG] 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3
+// [DEBUG] 0x0 ('')
+// [DEBUG] 0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff0b
+// [DEBUG] 0x9 ('  ')
+}
+
+#[test]
 fn test_op_max() {
     let program = "OP_1 OP_0 OP_MAX";
     let mut compiler = CompilerTraitImpl::new();

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -1,3 +1,4 @@
+use core::byte_array::ByteArrayTrait;
 use shinigami::compiler::CompilerTraitImpl;
 use shinigami::engine::EngineTraitImpl;
 
@@ -30,7 +31,7 @@ fn test_op_1() {
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
     // TODO: Is this the correct representation of 1?
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -48,7 +49,7 @@ fn test_op_add() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x02"];
+    let expected_stack = array!["\x02"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -66,7 +67,7 @@ fn test_op_sub() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x00"];
+    let expected_stack = array![""];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 
     let program = "OP_2 OP_1 OP_SUB";
@@ -81,13 +82,9 @@ fn test_op_sub() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
-}
 
-#[should_panic(expected: ('Option::unwrap failed.',))]
-#[test]
-fn test_op_sub_panic() {
     let program = "OP_1 OP_2 OP_SUB";
     let mut compiler = CompilerTraitImpl::new();
     let bytecode = compiler.compile(program);
@@ -100,13 +97,13 @@ fn test_op_sub_panic() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
-    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
-// ByteArray added to the stack (result of 1 - 2)
-// [DEBUG] 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3
-// [DEBUG] 0x0 ('')
-// [DEBUG] 0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff0b
-// [DEBUG] 0x9 ('  ')
+    let byte_array = dstack.at(dstack.len() - 1);
+    let element = byte_array.at(byte_array.len() - 1).unwrap();
+
+    let expected_element: u8 = 0x81; // -1
+
+    // let expected_stack = array!["\x81"];  this fails with non ASCII character error
+    assert_eq!(element, expected_element, "Stack is not equal to expected");
 }
 
 #[test]
@@ -123,7 +120,7 @@ fn test_op_max() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -139,7 +136,7 @@ fn test_op_depth_empty_stack() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
+    let expected_stack = array!["\0"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected for empty stack");
 }
 
@@ -154,7 +151,7 @@ fn test_op_2() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x02"];
+    let expected_stack = array!["\x02"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -172,7 +169,7 @@ fn test_op_depth_one_item() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 2, "Stack length is not 2");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01", "\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01", "\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected for one item");
 }
 
@@ -193,7 +190,7 @@ fn test_op_depth_multiple_items() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 3, "Stack length is not 3");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x02", "\0\0\0\0\0\0\0\x01", "\0\0\0\0\0\0\0\x02"];
+    let expected_stack = array!["\x02", "\x01", "\x02"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected for multiple items");
 }
 
@@ -210,7 +207,7 @@ fn test_op_TRUE() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -228,7 +225,7 @@ fn test_op_1add() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x02"];
+    let expected_stack = array!["\x02"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -244,7 +241,7 @@ fn test_op_3() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x03"];
+    let expected_stack = array!["\x03"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -260,7 +257,7 @@ fn test_op_4() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x04"];
+    let expected_stack = array!["\x04"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -276,7 +273,7 @@ fn test_op_5() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x05"];
+    let expected_stack = array!["\x05"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -292,7 +289,7 @@ fn test_op_6() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x06"];
+    let expected_stack = array!["\x06"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -308,7 +305,7 @@ fn test_op_7() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x07"];
+    let expected_stack = array!["\x07"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -324,7 +321,7 @@ fn test_op_8() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x08"];
+    let expected_stack = array!["\x08"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -340,7 +337,7 @@ fn test_op_9() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x09"];
+    let expected_stack = array!["\x09"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -356,7 +353,7 @@ fn test_op_10() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x0a"];
+    let expected_stack = array!["\x0a"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -372,7 +369,7 @@ fn test_op_11() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x0b"];
+    let expected_stack = array!["\x0b"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -388,7 +385,7 @@ fn test_op_12() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x0c"];
+    let expected_stack = array!["\x0c"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -404,7 +401,7 @@ fn test_op_13() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x0d"];
+    let expected_stack = array!["\x0d"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -420,7 +417,7 @@ fn test_op_14() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x0e"];
+    let expected_stack = array!["\x0e"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -436,7 +433,7 @@ fn test_op_15() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x0f"];
+    let expected_stack = array!["\x0f"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -452,6 +449,6 @@ fn test_op_16() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x10"];
+    let expected_stack = array!["\x10"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -100,9 +100,7 @@ fn test_op_sub_panic() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array![
-        "\0\0\0\0\0\0\0\x03618502788666131213697322783095070105623107215331596699973092056135872020480"
-    ];
+    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 // ByteArray added to the stack (result of 1 - 2)
 // [DEBUG] 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -1,5 +1,6 @@
 use shinigami::compiler::CompilerTraitImpl;
 use shinigami::engine::EngineTraitImpl;
+use shinigami::utils::int_to_bytes;
 
 #[test]
 fn test_op_0() {
@@ -96,18 +97,8 @@ fn test_op_sub() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    println!("{:?}", dstack);
-    let q: ByteArray = "Q";
-    let expected_stack = array![q];
-    println!("{:?}", expected_stack);
-    // this is needed to evaluate the result because
-    // array!["\x81"] fails with non ASCII character error
-    let byte_array = dstack.at(dstack.len() - 1);
-    let element = byte_array.at(byte_array.len() - 1).unwrap();
-
-    let expected_element: u8 = 0x81; // -1
-
-    assert_eq!(element, expected_element, "Stack is not equal to expected");
+    let expected_stack: Array<ByteArray> = array![int_to_bytes(-1)];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
 #[test]
@@ -160,7 +151,7 @@ fn test_op_if_true() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -180,7 +171,7 @@ fn test_op_notif_false() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -307,7 +298,7 @@ fn test_op_else_false() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -96,6 +96,10 @@ fn test_op_sub() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
+    println!("{:?}", dstack);
+    let q: ByteArray = "Q";
+    let expected_stack = array![q];
+    println!("{:?}", expected_stack);
     // this is needed to evaluate the result because
     // array!["\x81"] fails with non ASCII character error
     let byte_array = dstack.at(dstack.len() - 1);

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -51,3 +51,56 @@ fn test_op_add() {
     let expected_stack = array!["\0\0\0\0\0\0\0\x02"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
+
+#[test]
+fn test_op_sub() {
+    let program = "OP_1 OP_1 OP_SUB";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of run failed");
+
+    let dstack = engine.get_dstack();
+    // assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\x00"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+
+    let program = "OP_2 OP_1 OP_SUB";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of run failed");
+
+    let dstack = engine.get_dstack();
+    // assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+}
+
+
+#[should_panic(expected: ('Option::unwrap failed.',))]
+#[test]
+fn test_op_sub_panic() {
+    let program = "OP_1 OP_2 OP_SUB";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of run failed");
+
+    let dstack = engine.get_dstack();
+    // assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+}

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -1,4 +1,3 @@
-use core::byte_array::ByteArrayTrait;
 use shinigami::compiler::CompilerTraitImpl;
 use shinigami::engine::EngineTraitImpl;
 

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -85,7 +85,6 @@ fn test_op_sub() {
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
-
 #[should_panic(expected: ('Option::unwrap failed.',))]
 #[test]
 fn test_op_sub_panic() {
@@ -105,4 +104,9 @@ fn test_op_sub_panic() {
         "\0\0\0\0\0\0\0\x03618502788666131213697322783095070105623107215331596699973092056135872020480"
     ];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+// ByteArray added to the stack (result of 1 - 2)
+// [DEBUG] 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3
+// [DEBUG] 0x0 ('')
+// [DEBUG] 0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff0b
+// [DEBUG] 0x9 ('  ')
 }

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -97,12 +97,13 @@ fn test_op_sub() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
+    // this is needed to evaluate the result because
+    // array!["\x81"] fails with non ASCII character error
     let byte_array = dstack.at(dstack.len() - 1);
     let element = byte_array.at(byte_array.len() - 1).unwrap();
 
     let expected_element: u8 = 0x81; // -1
 
-    // let expected_stack = array!["\x81"];  this fails with non ASCII character error
     assert_eq!(element, expected_element, "Stack is not equal to expected");
 }
 

--- a/src/stack.cairo
+++ b/src/stack.cairo
@@ -21,6 +21,7 @@ pub impl ScriptStackImpl of ScriptStackTrait {
     fn push_int(ref self: ScriptStack, value: i64) {
         let mut bytes = "";
         bytes.append_word(value.into(), 8);
+        println!("{}", bytes);
         self.push_byte_array(bytes);
     }
 

--- a/src/stack.cairo
+++ b/src/stack.cairo
@@ -21,7 +21,6 @@ pub impl ScriptStackImpl of ScriptStackTrait {
     fn push_int(ref self: ScriptStack, value: i64) {
         let mut bytes = "";
         bytes.append_word(value.into(), 8);
-        println!("{}", bytes);
         self.push_byte_array(bytes);
     }
 

--- a/src/stack.cairo
+++ b/src/stack.cairo
@@ -1,4 +1,3 @@
-use core::nullable::NullableTrait;
 use core::dict::Felt252DictEntryTrait;
 use shinigami::utils;
 

--- a/src/stack.cairo
+++ b/src/stack.cairo
@@ -1,5 +1,6 @@
 use core::nullable::NullableTrait;
 use core::dict::Felt252DictEntryTrait;
+use shinigami::utils;
 
 #[derive(Destruct)]
 pub struct ScriptStack {
@@ -19,8 +20,7 @@ pub impl ScriptStackImpl of ScriptStackTrait {
     }
 
     fn push_int(ref self: ScriptStack, value: i64) {
-        let mut bytes = "";
-        bytes.append_word(value.into(), 8);
+        let mut bytes = utils::int_to_bytes(value);
         self.push_byte_array(bytes);
     }
 

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -1,0 +1,57 @@
+use core::traits::TryInto;
+use core::byte_array::ByteArrayTrait;
+use core::traits::BitAnd;
+
+const TWO_POW_EIGHT: u256 = 0x100;
+const SIGN_BIT: u8 = 0x80;
+
+
+// `int_to_bytes` returns the number serialized as a little endian with a sign bit
+pub fn int_to_bytes(mut value: i64) -> ByteArray {
+    let mut bytes: ByteArray = "";
+    if value == 0 {
+        return bytes;
+    }
+
+    let is_negative: bool = value < 0;
+    if is_negative {
+        value = -value;
+    }
+
+    let value_felt: felt252 = value.into();
+    let mut value_u256: u256 = value_felt.into();
+    let mask: u256 = 0xff;
+
+    while value_u256 > 0 {
+        let item: u256 = value_u256 & mask;
+        let byte: u8 = item.try_into().unwrap();
+        bytes.append_byte(byte);
+
+        value_u256 = value_u256 / TWO_POW_EIGHT;
+    };
+
+    if bytes.at((bytes.len() - 1)).unwrap() & SIGN_BIT != 0 {
+        let mut extra_byte: u8 = 0;
+        if is_negative {
+            extra_byte = 0x80;
+        }
+        bytes.append_byte(SIGN_BIT);
+
+        return bytes;
+    } else if is_negative {
+        let mut last_byte: u8 = bytes.at((bytes.len() - 1)).unwrap();
+        last_byte = last_byte | SIGN_BIT;
+
+        let mut new_bytes: ByteArray = "";
+        let mut i = 0;
+        while i < bytes.len() - 1 {
+            new_bytes.append_byte(bytes.at(i).unwrap());
+        };
+
+        new_bytes.append_byte(last_byte);
+
+        return new_bytes;
+    }
+
+    return bytes;
+}

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -1,7 +1,3 @@
-use core::traits::TryInto;
-use core::byte_array::ByteArrayTrait;
-use core::traits::BitAnd;
-
 const TWO_POW_EIGHT: u256 = 0x100;
 const SIGN_BIT: u8 = 0x80;
 


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #11 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->

Hi @b-j-roberts 

I also added `OP_2` opcode for testing.

I have 2 questions:

- bitcoin wiki says arithmetic operations operates on `i32` not `i64`, is it normal that we use `i64`?
https://en.bitcoin.it/wiki/Script

wiki says : "Note: Arithmetic inputs are limited to signed 32-bit integers, but may overflow their output."

this is why I tested the `OP_SUB` for 
- `1 - 1`
- `2 - 1`
- `1 - 2`

in the last case, i guess an overflow is supposed to happen and return `-1` , currently represented as a `i64` 
But as you can see in test, i get an unwrap error, related to the `assert_eq!` usage on the last line. is it an issue with the macro? but it should work and print the result right?

when i print the ByteArray that will be added to the `ScriptStack` , i get this : 

```
    fn push_int(ref self: ScriptStack, value: i64) {
        let mut bytes = "";
        bytes.append_word(value.into(), 8);
        println!("{}", bytes);
        self.push_byte_array(bytes);
    }
```

```
[DEBUG] 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3
[DEBUG] 0x0 ('')
[DEBUG] 0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff0b
[DEBUG] 0x9 ('  ')
```


