### PR TITLE
[feat]  `OP_LESSTHAN` implementation

### DIFF
--- a/src/compiler.cairo
+++ b/src/compiler.cairo
@@ -40,6 +40,7 @@ pub impl CompilerTraitImpl of CompilerTrait {
         opcodes.insert('OP_1ADD', Opcode::OP_1ADD);
         opcodes.insert('OP_ADD', Opcode::OP_ADD);
         opcodes.insert('OP_MAX', Opcode::OP_MAX);
+        opcodes.insert('OP_LESSTHAN', Opcode::OP_LESSTHAN);
         Compiler { opcodes }
     }
 

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -20,6 +20,7 @@ pub mod Opcode {
     pub const OP_DEPTH: u8 = 116;
     pub const OP_1ADD: u8 = 139;
     pub const OP_ADD: u8 = 147;
+    pub const OP_LESSTHAN: u8 = 159;
     pub const OP_MAX: u8 = 164;
 
     use shinigami::engine::Engine;
@@ -185,7 +186,7 @@ pub mod Opcode {
             156 => not_implemented(ref engine),
             157 => not_implemented(ref engine),
             158 => not_implemented(ref engine),
-            159 => not_implemented(ref engine),
+            159 => opcode_lessthan(ref engine),
             160 => not_implemented(ref engine),
             161 => not_implemented(ref engine),
             162 => not_implemented(ref engine),
@@ -232,6 +233,16 @@ pub mod Opcode {
             a
         } else {
             b
+        });
+    }
+
+    fn opcode_lessthan(ref engine: Engine) {
+        let a = engine.dstack.pop_int();
+        let b = engine.dstack.pop_int();
+        engine.dstack.push_int(if b < a {
+            1
+        } else {
+            0
         });
     }
 }

--- a/src/opcodes/opcodes.cairo
+++ b/src/opcodes/opcodes.cairo
@@ -343,7 +343,6 @@ pub mod Opcode {
         });
     }
 
-<<<<<<< HEAD
     fn opcode_lessthan(ref engine: Engine) {
         let a = engine.dstack.pop_int();
         let b = engine.dstack.pop_int();
@@ -352,11 +351,11 @@ pub mod Opcode {
         } else {
             0
         });
-=======
+    }
+
     fn opcode_fromaltstack(ref engine: Engine) {
         //TODO: Error handling
         let a = engine.astack.pop_byte_array();
         engine.dstack.push_byte_array(a);
->>>>>>> main
     }
 }

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -398,3 +398,61 @@ fn test_op_16() {
     let expected_stack = array!["\0\0\0\0\0\0\0\x10"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
+
+
+#[test]
+fn test_op_lessthan() {
+    let program = "OP_1 OP_2 OP_LESSTHAN";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of step failed");
+
+    let dstack = engine.get_dstack();
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+}
+
+#[test]
+fn test_op_lessthan_reverse() {
+    let program = "OP_2 OP_1 OP_LESSTHAN";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of step failed");
+
+    let dstack = engine.get_dstack();
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+}
+
+#[test]
+fn test_op_lessthan_equal() {
+    let program = "OP_1 OP_1 OP_LESSTHAN";
+    let mut compiler = CompilerTraitImpl::new();
+    let bytecode = compiler.compile(program);
+    let mut engine = EngineTraitImpl::new(bytecode);
+
+    let _ = engine.step();
+    let _ = engine.step();
+    let res = engine.step();
+    assert!(res, "Execution of step failed");
+
+    let dstack = engine.get_dstack();
+    assert_eq!(dstack.len(), 1, "Stack length is not 1");
+
+    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
+    assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
+}

--- a/src/opcodes/tests/test_opcodes.cairo
+++ b/src/opcodes/tests/test_opcodes.cairo
@@ -511,7 +511,7 @@ fn test_op_lessthan() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\x01"];
+    let expected_stack = array!["\x01"];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -530,7 +530,7 @@ fn test_op_lessthan_reverse() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
+    let expected_stack = array![""];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }
 
@@ -549,6 +549,6 @@ fn test_op_lessthan_equal() {
     let dstack = engine.get_dstack();
     assert_eq!(dstack.len(), 1, "Stack length is not 1");
 
-    let expected_stack = array!["\0\0\0\0\0\0\0\0"];
+    let expected_stack = array![""];
     assert_eq!(dstack, expected_stack.span(), "Stack is not equal to expected");
 }


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [X] issue #13 
- [X] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [X] code change includes tests

<!-- PR description below -->

I've added 3 tests, I can probably collapse the tests into a common function that just takes `script`, `expected stack` and we can reuse it across other similar comparison like tests, but thought that might be premature and opted to just duplicate for the time being.