### PR TITLE
Fix Bug with PICK Opcode

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -7,6 +7,7 @@ pub mod Error {
     pub const OPCODE_RESERVED: felt252 = 'Opcode reserved';
     pub const OPCODE_NOT_IMPLEMENTED: felt252 = 'Opcode not implemented';
     pub const OPCODE_DISABLED: felt252 = 'Opcode is disabled';
+    pub const INVALID_STACK_OPS: felt252 = 'Invalid Stack Operation';
 }
 
 pub fn byte_array_err(err: felt252) -> ByteArray {

--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -7,7 +7,6 @@ pub mod Error {
     pub const OPCODE_RESERVED: felt252 = 'Opcode reserved';
     pub const OPCODE_NOT_IMPLEMENTED: felt252 = 'Opcode not implemented';
     pub const OPCODE_DISABLED: felt252 = 'Opcode is disabled';
-    pub const INVALID_STACK_OPS: felt252 = 'Invalid Stack Operation';
 }
 
 pub fn byte_array_err(err: felt252) -> ByteArray {

--- a/src/stack.cairo
+++ b/src/stack.cairo
@@ -187,7 +187,12 @@ pub impl ScriptStackImpl of ScriptStackTrait {
     }
 
     fn pick_n(ref self: ScriptStack, idx: i32) -> Result<(), felt252> {
+        if idx < 0 {
+            return Result::Err(Error::INVALID_STACK_OPS);
+        }
+
         let so = self.peek_byte_array(idx.try_into().unwrap())?;
+
         self.push_byte_array(so);
         return Result::Ok(());
     }

--- a/src/stack.cairo
+++ b/src/stack.cairo
@@ -188,21 +188,30 @@ pub impl ScriptStackImpl of ScriptStackTrait {
 
     fn pick_n(ref self: ScriptStack, idx: i32) -> Result<(), felt252> {
         if idx < 0 {
-            return Result::Err(Error::INVALID_STACK_OPS);
+            return Result::Err(Error::STACK_OUT_OF_RANGE);
         }
 
-        let so = self.peek_byte_array(idx.try_into().unwrap())?;
+        let idxU32: u32 = idx.try_into().unwrap();
+        if idxU32 >= self.len {
+            return Result::Err(Error::STACK_OUT_OF_RANGE);
+        }
+
+        let so = self.peek_byte_array(idxU32)?;
 
         self.push_byte_array(so);
         return Result::Ok(());
     }
 
     fn roll_n(ref self: ScriptStack, n: i32) -> Result<(), felt252> {
-        if n >= self.len.try_into().unwrap() {
+        if n < 0 {
+            return Result::Err(Error::STACK_OUT_OF_RANGE);
+        }
+        let nU32: u32 = n.try_into().unwrap();
+        if nU32 >= self.len {
             return Result::Err(Error::STACK_OUT_OF_RANGE);
         }
 
-        let value = self.nip_n(n.try_into().unwrap())?;
+        let value = self.nip_n(nU32)?;
         self.push_byte_array(value);
         return Result::Ok(());
     }


### PR DESCRIPTION


- [x] issue #137 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

The bug was cause due to passing of negative number i.e '1 -1 PICK'

the following error is return when a -1 is pass 

`Execution failed: Invalid Stack Operation`


