### PR TITLE
[bug] add error handling to `pull_data` when out of bound

### DIFF
--- a/src/engine.cairo
+++ b/src/engine.cairo
@@ -83,7 +83,7 @@ pub impl EngineImpl of EngineTrait {
         let mut end = i + len;
         let script = *(self.scripts[self.script_idx]);
         if end > script.len() {
-            return Result::Err(Error::SCRIPT_FAILED);
+            return Result::Err(Error::SCRIPT_INVALID);
         }
         while i < end {
             data.append_byte(script[i]);

--- a/src/engine.cairo
+++ b/src/engine.cairo
@@ -39,7 +39,7 @@ pub trait EngineTrait {
         script_pubkey: @ByteArray, transaction: Transaction, tx_idx: u32, flags: u32, amount: i64
     ) -> Engine;
     // Pulls the next len bytes from the script and advances the program counter
-    fn pull_data(ref self: Engine, len: usize) -> ByteArray;
+    fn pull_data(ref self: Engine, len: usize) -> Result<ByteArray, felt252>;
     fn get_dstack(ref self: Engine) -> Span<ByteArray>;
     fn get_astack(ref self: Engine) -> Span<ByteArray>;
     // Executes the next instruction in the script
@@ -76,21 +76,21 @@ pub impl EngineImpl of EngineTrait {
         }
     }
 
-    fn pull_data(ref self: Engine, len: usize) -> ByteArray {
+    fn pull_data(ref self: Engine, len: usize) -> Result<ByteArray, felt252> {
         // TODO: check bounds with error handling
         let mut data = "";
         let mut i = self.opcode_idx + 1;
         let mut end = i + len;
         let script = *(self.scripts[self.script_idx]);
         if end > script.len() {
-            end = script.len();
+            return Result::Err(Error::SCRIPT_FAILED);
         }
         while i < end {
             data.append_byte(script[i]);
             i += 1;
         };
         self.opcode_idx = end - 1;
-        return data;
+        return Result::Ok(data);
     }
 
     fn get_dstack(ref self: Engine) -> Span<ByteArray> {

--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -8,6 +8,7 @@ pub mod Error {
     pub const OPCODE_RESERVED: felt252 = 'Opcode reserved';
     pub const OPCODE_NOT_IMPLEMENTED: felt252 = 'Opcode not implemented';
     pub const OPCODE_DISABLED: felt252 = 'Opcode is disabled';
+    pub const SCRIPT_INVALID: felt252 = 'Invalid script data';
 }
 
 pub fn byte_array_err(err: felt252) -> ByteArray {

--- a/src/opcodes/constants.cairo
+++ b/src/opcodes/constants.cairo
@@ -8,15 +8,15 @@ pub fn opcode_false(ref engine: Engine) -> Result<(), felt252> {
 }
 
 pub fn opcode_push_data(n: usize, ref engine: Engine) -> Result<(), felt252> {
-    let data = engine.pull_data(n);
+    let data = engine.pull_data(n)?;
     engine.dstack.push_byte_array(data);
     return Result::Ok(());
 }
 
 // TODO: Issue when these are in if block
 pub fn opcode_push_data_x(n: usize, ref engine: Engine) -> Result<(), felt252> {
-    let data_len: usize = utils::byte_array_to_felt252(@engine.pull_data(n)).try_into().unwrap();
-    let data = engine.pull_data(data_len);
+    let data_len: usize = utils::byte_array_to_felt252(@engine.pull_data(n)?).try_into().unwrap();
+    let data = engine.pull_data(data_len)?;
     engine.dstack.push_byte_array(data);
     return Result::Ok(());
 }

--- a/src/opcodes/tests/test_constants.cairo
+++ b/src/opcodes/tests/test_constants.cairo
@@ -105,7 +105,7 @@ fn test_op_push_data1() {
 }
 #[test]
 fn test_op_push_data2() {
-    let program = "OP_PUSHDATA2 0x0100 0x42";
+    let program = "OP_PUSHDATA2 0x0001 0x42";
     let mut engine = utils::test_compile_and_run(program);
     utils::check_dstack_size(ref engine, 1);
     let expected_stack = array![hex_to_bytecode(@"0x42")];
@@ -124,11 +124,16 @@ fn test_op_push_data2() {
     utils::check_dstack_size(ref engine, 1);
     let expected_stack = array![hex_to_bytecode(@byte_data)];
     utils::check_expected_dstack(ref engine, expected_stack.span());
+
+    let program: ByteArray = "OP_PUSHDATA2 0x01 NOP";
+    let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_FAILED);
+    // fail to pull data so nothing is pushed into the dstack.
+    utils::check_dstack_size(ref engine, 0);
 }
 
 #[test]
 fn test_op_push_data4() {
-    let program = "OP_PUSHDATA4 0x00000100 0x42";
+    let program = "OP_PUSHDATA4 0x00000001 0x42";
     let mut engine = utils::test_compile_and_run(program);
     utils::check_dstack_size(ref engine, 1);
     let expected_stack = array![hex_to_bytecode(@"0x42")];
@@ -147,5 +152,5 @@ fn test_op_push_data4() {
     utils::check_dstack_size(ref engine, 1);
     let expected_stack = array![hex_to_bytecode(@byte_data)];
     utils::check_expected_dstack(ref engine, expected_stack.span());
-    // TODO: test with 0x01000000?
+    // TODO: test with ?
 }

--- a/src/opcodes/tests/test_constants.cairo
+++ b/src/opcodes/tests/test_constants.cairo
@@ -152,5 +152,9 @@ fn test_op_push_data4() {
     utils::check_dstack_size(ref engine, 1);
     let expected_stack = array![hex_to_bytecode(@byte_data)];
     utils::check_expected_dstack(ref engine, expected_stack.span());
+    
     // TODO: test with ?
+    let program = "OP_PUSHDATA4 0x01 NOP";
+    let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_FAILED);
+    utils::check_dstack_size(ref engine, 0);
 }

--- a/src/opcodes/tests/test_constants.cairo
+++ b/src/opcodes/tests/test_constants.cairo
@@ -126,7 +126,7 @@ fn test_op_push_data2() {
     utils::check_expected_dstack(ref engine, expected_stack.span());
 
     let program: ByteArray = "OP_PUSHDATA2 0x01 NOP";
-    let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_FAILED);
+    let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_INVALID);
     // fail to pull data so nothing is pushed into the dstack.
     utils::check_dstack_size(ref engine, 0);
 }
@@ -155,6 +155,6 @@ fn test_op_push_data4() {
     
     // TODO: test with ?
     let program = "OP_PUSHDATA4 0x01 NOP";
-    let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_FAILED);
+    let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_INVALID);
     utils::check_dstack_size(ref engine, 0);
 }

--- a/src/opcodes/tests/test_constants.cairo
+++ b/src/opcodes/tests/test_constants.cairo
@@ -103,6 +103,7 @@ fn test_op_push_data1() {
     let expected_stack = array![hex_to_bytecode(@"0x42434445464748494A4B4C4D4E4F5051")];
     utils::check_expected_dstack(ref engine, expected_stack.span());
 }
+
 #[test]
 fn test_op_push_data2() {
     let program = "OP_PUSHDATA2 0x0001 0x42";
@@ -125,7 +126,8 @@ fn test_op_push_data2() {
     let expected_stack = array![hex_to_bytecode(@byte_data)];
     utils::check_expected_dstack(ref engine, expected_stack.span());
 
-    let program: ByteArray = "OP_PUSHDATA2 0x01 NOP";
+    // Test error case: data bytes fewer than specified in length field
+    let program: ByteArray = "OP_PUSHDATA2 0x01 0x4243";
     let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_INVALID);
     // fail to pull data so nothing is pushed into the dstack.
     utils::check_dstack_size(ref engine, 0);
@@ -152,9 +154,9 @@ fn test_op_push_data4() {
     utils::check_dstack_size(ref engine, 1);
     let expected_stack = array![hex_to_bytecode(@byte_data)];
     utils::check_expected_dstack(ref engine, expected_stack.span());
-    
-    // TODO: test with ?
-    let program = "OP_PUSHDATA4 0x01 NOP";
+
+    // Test error case: data bytes fewer than specified in length field
+    let program = "OP_PUSHDATA4 0x01 0x4243";
     let mut engine = utils::test_compile_and_run_err(program, Error::SCRIPT_INVALID);
     utils::check_dstack_size(ref engine, 0);
 }


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] Fixes #132,
- [x] Fixes #133 
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [x] code change includes tests

<!-- PR description below -->

## Description

Add error handling to `pull_data`, specifically when there is not enough data available to pull.
