### PR TITLE
bug: fn byte_array_to_felt252_[big/little]_endian

### DIFF
--- a/src/compiler.cairo
+++ b/src/compiler.cairo
@@ -344,7 +344,7 @@ pub impl CompilerImpl of CompilerTrait {
                 ByteArrayTrait::append(ref bytecode, @utils::number_to_bytecode(script_item));
             } else {
                 // TODO: Check opcode exists
-                bytecode.append_byte(self.opcodes.get(utils::byte_array_to_felt252(script_item)));
+                bytecode.append_byte(self.opcodes.get(utils::byte_array_to_felt252_big_endian(script_item)));
             }
             i += 1;
         };

--- a/src/compiler.cairo
+++ b/src/compiler.cairo
@@ -344,7 +344,10 @@ pub impl CompilerImpl of CompilerTrait {
                 ByteArrayTrait::append(ref bytecode, @utils::number_to_bytecode(script_item));
             } else {
                 // TODO: Check opcode exists
-                bytecode.append_byte(self.opcodes.get(utils::byte_array_to_felt252_big_endian(script_item)));
+                bytecode
+                    .append_byte(
+                        self.opcodes.get(utils::byte_array_to_felt252_big_endian(script_item))
+                    );
             }
             i += 1;
         };

--- a/src/opcodes/constants.cairo
+++ b/src/opcodes/constants.cairo
@@ -14,7 +14,7 @@ pub fn opcode_push_data(n: usize, ref engine: Engine) -> Result<(), felt252> {
 }
 
 pub fn opcode_push_data_x(n: usize, ref engine: Engine) -> Result<(), felt252> {
-    let data_len: usize = utils::byte_array_to_felt252_endian(@engine.pull_data(n)?)
+    let data_len: usize = utils::byte_array_to_felt252_little_endian(@engine.pull_data(n)?)
         .try_into()
         .unwrap();
     let data = engine.pull_data(data_len)?;

--- a/src/opcodes/constants.cairo
+++ b/src/opcodes/constants.cairo
@@ -14,7 +14,9 @@ pub fn opcode_push_data(n: usize, ref engine: Engine) -> Result<(), felt252> {
 }
 
 pub fn opcode_push_data_x(n: usize, ref engine: Engine) -> Result<(), felt252> {
-    let data_len: usize = utils::byte_array_to_felt252_endian(@engine.pull_data(n)?).try_into().unwrap();
+    let data_len: usize = utils::byte_array_to_felt252_endian(@engine.pull_data(n)?)
+        .try_into()
+        .unwrap();
     let data = engine.pull_data(data_len)?;
     engine.dstack.push_byte_array(data);
     return Result::Ok(());

--- a/src/opcodes/constants.cairo
+++ b/src/opcodes/constants.cairo
@@ -14,7 +14,7 @@ pub fn opcode_push_data(n: usize, ref engine: Engine) -> Result<(), felt252> {
 }
 
 pub fn opcode_push_data_x(n: usize, ref engine: Engine) -> Result<(), felt252> {
-    let data_len: usize = utils::byte_array_to_felt252(@engine.pull_data(n)?).try_into().unwrap();
+    let data_len: usize = utils::byte_array_to_felt252_endian(@engine.pull_data(n)?).try_into().unwrap();
     let data = engine.pull_data(data_len)?;
     engine.dstack.push_byte_array(data);
     return Result::Ok(());

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -202,6 +202,19 @@ pub fn byte_array_to_felt252(byte_array: @ByteArray) -> felt252 {
     value
 }
 
+pub fn byte_array_to_felt252_endian(byte_array: @ByteArray) -> felt252 {
+    let mut byte_shift = 1;
+    let mut value = 0;
+    let mut i = 0;
+    let byte_array_len = byte_array.len();
+    while i < byte_array_len {
+        value += byte_shift * byte_array[i].into();
+        byte_shift *= 256;
+        i += 1;
+    };
+    value
+}
+
 // TODO: More efficient way to do this
 pub fn felt252_to_byte_array(value: felt252) -> ByteArray {
     let byte_shift = 256;

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -189,8 +189,7 @@ pub fn number_to_bytecode(script_item: @ByteArray) -> ByteArray {
     bytecode
 }
 
-// TODO: Endian
-pub fn byte_array_to_felt252(byte_array: @ByteArray) -> felt252 {
+pub fn byte_array_to_felt252_big_endian(byte_array: @ByteArray) -> felt252 {
     let byte_shift = 256;
     let mut value = 0;
     let mut i = 0;
@@ -202,7 +201,7 @@ pub fn byte_array_to_felt252(byte_array: @ByteArray) -> felt252 {
     value
 }
 
-pub fn byte_array_to_felt252_endian(byte_array: @ByteArray) -> felt252 {
+pub fn byte_array_to_felt252_little_endian(byte_array: @ByteArray) -> felt252 {
     let mut byte_shift = 1;
     let mut value = 0;
     let mut i = 0;


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #170 
- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests

<!-- PR description below -->

New fn `byte_array_to_felt252_endian` is designed to take in little-endian numbers, unlike `byte_array_to_felt252`, which takes in big-endian numbers. I'm unsure if `byte_array_to_felt252` has relevance elsewhere in the project, so I created a new function rather than editing the existing one.