### PR TITLE
fix: add check for discouraged ops

### DIFF
--- a/packages/engine/src/opcodes/constants.cairo
+++ b/packages/engine/src/opcodes/constants.cairo
@@ -1,6 +1,10 @@
 use crate::engine::{Engine, EngineExtrasTrait};
 use crate::stack::ScriptStackTrait;
 use shinigami_utils::byte_array::byte_array_to_felt252_le;
+use crate::opcodes::{Opcode};
+use crate::errors::Error;
+use crate::scriptflags::ScriptFlags;
+
 
 pub fn opcode_false<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
     engine.dstack.push_byte_array("");
@@ -9,6 +13,7 @@ pub fn opcode_false<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
 
 pub fn opcode_push_data<T, +Drop<T>>(n: usize, ref engine: Engine<T>) -> Result<(), felt252> {
     let data = EngineExtrasTrait::<T>::pull_data(ref engine, n)?;
+    check_discouraged_opcode(ref engine, @data)?;
     engine.dstack.push_byte_array(data);
     return Result::Ok(());
 }
@@ -28,5 +33,26 @@ pub fn opcode_n<T, +Drop<T>>(n: i64, ref engine: Engine<T>) -> Result<(), felt25
 
 pub fn opcode_1negate<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
     engine.dstack.push_int(-1);
+    return Result::Ok(());
+}
+
+pub fn check_discouraged_opcode<T, +Drop<T>>(ref engine: Engine<T>, data: @ByteArray) -> Result<(), felt252>{
+    if !engine.has_flag(ScriptFlags::ScriptDiscourageUpgradableNops){
+        return Result::Ok(());
+    }
+    let nop_opcodes = array![
+        Opcode::OP_NOP1, Opcode::OP_CHECKLOCKTIMEVERIFY, Opcode::OP_CHECKSEQUENCEVERIFY, Opcode::OP_NOP4, Opcode::OP_NOP5,
+        Opcode::OP_NOP6, Opcode::OP_NOP7, Opcode::OP_NOP8, Opcode::OP_NOP9, Opcode::OP_NOP10,
+    ];
+    let mut result = false;
+    for opcode in nop_opcodes{
+        if data[0] == opcode{
+            result = true;
+            break;
+        }
+    };
+    if result{
+        return Result::Err(Error::SCRIPT_DISCOURAGE_UPGRADABLE_NOPS);
+    }
     return Result::Ok(());
 }


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests

<!-- PR description below -->

fixes 
```
scarb cairo-run --package shinigami_cmds '[[],59389374992760294021292601,11,[127663847454887939587139309636239821029460283340348563361134020274702083684],672225353062291822653026351361043029027015304412105792318784106841588044,30,[],141695097775878930382826583948656689861065920770142587191887339894720122963,31]'
```

`["1 0x01 0xb9","HASH160 0x14 0x15727299b05b45fdaf9ac9ecf7565cfe27c3e567 EQUAL","P2SH,DISCOURAGE_UPGRADABLE_NOPS","DISCOURAGE_UPGRADABLE_NOPS","Discouraged NOP10 in redeemScript"],`
