### PR TITLE
fix: strict encoding boolean

### DIFF
--- a/packages/engine/src/signature/signature.cairo
+++ b/packages/engine/src/signature/signature.cairo
@@ -429,8 +429,8 @@ pub fn parse_base_sig_and_pk<
 >(
     ref vm: Engine<T>, pk_bytes: @ByteArray, sig_bytes: @ByteArray
 ) -> Result<(Secp256k1Point, Signature, u32), felt252> {
-    let strict_encoding = vm.has_flag(ScriptFlags::ScriptVerifyStrictEncoding);
     let verify_der = vm.has_flag(ScriptFlags::ScriptVerifyDERSignatures);
+    let strict_encoding = vm.has_flag(ScriptFlags::ScriptVerifyStrictEncoding) || verify_der;
     if sig_bytes.len() == 0 {
         return if strict_encoding {
             Result::Err(Error::SCRIPT_ERR_SIG_DER)
@@ -442,7 +442,6 @@ pub fn parse_base_sig_and_pk<
     // TODO: strct encoding
     let hash_type_offset: usize = sig_bytes.len() - 1;
     let hash_type: u32 = sig_bytes[hash_type_offset].into();
-
     if let Result::Err(e) = check_hash_type_encoding(ref vm, hash_type) {
         return if verify_der {
             Result::Err(Error::SCRIPT_ERR_SIG_DER)

--- a/tests/run-sig-der-tests.sh
+++ b/tests/run-sig-der-tests.sh
@@ -5,6 +5,7 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 BASE_DIR=$SCRIPT_DIR/..
+TEXT_TO_BYTE_ARRAY_SCRIPT="$BASE_DIR/scripts/text_to_byte_array.sh"
 
 echo "Building shinigami..."
 cd $BASE_DIR && scarb build
@@ -74,9 +75,9 @@ jq -c '.[]' $SCRIPT_TESTS_JSON | {
     # echo "                  "
 
     # Run the test
-    ENCODED_SCRIPT_SIG=$($SCRIPT_DIR/text_to_byte_array.sh "$scriptSig") # Encoded like [["123", "456", ...], "789", 3]
-    ENCODED_SCRIPT_PUB_KEY=$($SCRIPT_DIR/text_to_byte_array.sh "$scriptPubKey") # Encoded like [["123", "456", ...], "789", 3]
-    ENCODED_FLAGS=$($SCRIPT_DIR/text_to_byte_array.sh "$flags") # Encoded like [["123", "456", ...], "789", 3]
+    ENCODED_SCRIPT_SIG=$($TEXT_TO_BYTE_ARRAY_SCRIPT "$scriptSig") # Encoded like [["123", "456", ...], "789", 3]
+    ENCODED_SCRIPT_PUB_KEY=$($TEXT_TO_BYTE_ARRAY_SCRIPT "$scriptPubKey") # Encoded like [["123", "456", ...], "789", 3]
+    ENCODED_FLAGS=$($TEXT_TO_BYTE_ARRAY_SCRIPT "$flags") # Encoded like [["123", "456", ...], "789", 3]
     # Remove the outer brackets and join the arrays
     TRIMMED_SCRIPT_SIG=$(sed 's/^\[\(.*\)\]$/\1/' <<< $ENCODED_SCRIPT_SIG)
     TRIMMED_SCRIPT_PUB_KEY=$(sed 's/^\[\(.*\)\]$/\1/' <<< $ENCODED_SCRIPT_PUB_KEY)
@@ -86,7 +87,7 @@ jq -c '.[]' $SCRIPT_TESTS_JSON | {
     if [ $has_witness == "true" ]; then
       #TODO: Value
       echo "  ScriptSig: '$scriptSig' -- ScriptPubKey: '$scriptPubKey' -- Flags: '$flags' -- Expected: $expected_scripterror -- Witness: $witness"
-      ENCODED_WITNESS=$($SCRIPT_DIR/text_to_byte_array.sh "$witness")
+      ENCODED_WITNESS=$($TEXT_TO_BYTE_ARRAY_SCRIPT "$witness")
       TRIMMED_WITNESS=$(sed 's/^\[\(.*\)\]$/\1/' <<< $ENCODED_WITNESS)
       JOINED_INPUT="[$TRIMMED_SCRIPT_SIG,$TRIMMED_SCRIPT_PUB_KEY,$TRIMMED_FLAGS,$TRIMMED_WITNESS]"
       RESULT=$(cd $BASE_DIR && scarb cairo-run --package shinigami_cmds --function main_with_witness --no-build $JOINED_INPUT)


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests

<!-- PR description below -->

This fixes all tests in `sig_der_failing_tests.json`. fix the bug in the last PR #251, where I seperate `strict_encoding` and `der_sig` flag.