### PR TITLE
refactor: use sha256 utils

### DIFF
--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -8,7 +8,7 @@ use crate::signature::signature;
 use crate::signature::sighash;
 use crate::signature::signature::BaseSigVerifierTrait;
 use starknet::secp256_trait::{is_valid_signature};
-use core::sha256::compute_sha256_byte_array;
+use shinigami_utils::hash::sha256_byte_array;
 use crate::opcodes::utils;
 use crate::scriptnum::ScriptNum;
 use crate::errors::Error;
@@ -17,52 +17,24 @@ const MAX_KEYS_PER_MULTISIG: i64 = 20;
 
 pub fn opcode_sha256<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
     let arr = @engine.dstack.pop_byte_array()?;
-    let res = compute_sha256_byte_array(arr).span();
-    let mut res_bytes: ByteArray = "";
-    let mut i: usize = 0;
-    let end = res.len();
-    while i != end {
-        res_bytes.append_word((*res[i]).into(), 4);
-        i += 1;
-    };
-    engine.dstack.push_byte_array(res_bytes);
+    let res = sha256_byte_array(arr);
+    engine.dstack.push_byte_array(res);
     return Result::Ok(());
 }
 
 pub fn opcode_hash160<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
     let m = engine.dstack.pop_byte_array()?;
-    let res = compute_sha256_byte_array(@m).span();
-    let mut res_bytes: ByteArray = "";
-    let mut i: usize = 0;
-    let end = res.len();
-    while i != end {
-        res_bytes.append_word((*res[i]).into(), 4);
-        i += 1;
-    };
-    let h: ByteArray = ripemd160::ripemd160_hash(@res_bytes).into();
+    let res = sha256_byte_array(@m);
+    let h: ByteArray = ripemd160::ripemd160_hash(@res).into();
     engine.dstack.push_byte_array(h);
     return Result::Ok(());
 }
 
 pub fn opcode_hash256<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
     let m = engine.dstack.pop_byte_array()?;
-    let res = compute_sha256_byte_array(@m).span();
-    let mut res_bytes: ByteArray = "";
-    let mut i: usize = 0;
-    let end = res.len();
-    while i != end {
-        res_bytes.append_word((*res[i]).into(), 4);
-        i += 1;
-    };
-    let res2 = compute_sha256_byte_array(@res_bytes).span();
-    let mut res2_bytes: ByteArray = "";
-    let mut j: usize = 0;
-    let end = res2.len();
-    while j != end {
-        res2_bytes.append_word((*res2[j]).into(), 4);
-        j += 1;
-    };
-    engine.dstack.push_byte_array(res2_bytes);
+    let res = sha256_byte_array(@m);
+    let res2 = sha256_byte_array(@res);
+    engine.dstack.push_byte_array(res2);
     return Result::Ok(());
 }
 


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests

<!-- PR description below -->

## Description
When I working on fixing the test, I came across this improvement. This PR uses `sha256_byte_array` helper where possible