### PR TITLE
taproot::new

### DIFF
--- a/packages/engine/src/signature/constants.cairo
+++ b/packages/engine/src/signature/constants.cairo
@@ -44,3 +44,8 @@ pub const WITNESS_V0_PUB_KEY_HASH_LEN: usize = 22;
 
 pub const MAX_U128: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 pub const MAX_U32: u32 = 0xFFFFFFFF;
+
+pub const SCHNORR_SIGNATURE_LEN: usize = 64;
+
+pub const PUB_KEY_BYTES_LEN: usize = 32;
+pub const PUB_KEY_BYTES_LEN_COMPRESSED: usize = 33;


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests

<!-- PR description below -->
- parse_schnorr_pub_key: Had already been implemented

- TaprootSigVerifierImpl::new: uses the reference from btcd https://github.com/btcsuite/btcd/blob/24eb815168f49dea84767817717a11bd7928eb23/txscript/sigvalidate.go#L313
