### PR TITLE
[dev] typos header.tsx

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -53,7 +53,7 @@ const MobileMenu: FC<MobileMenuProps> = ({ isOpen, onClose, onOpenModal }) => {
             href="https://github.com/keep-starknet-strange/shinigami"
             target="_blank"
           >
-            <button className="text-white w-full text-center bg-[#111111] py-2.5 rounded-md flex row items-center justify-center">
+            <button className="text-white w-full text-center bg-[#111111] py-2.5 rounded-md flex flex-row items-center justify-center">
               <div className="flex flex-row items-center space-x-1">
                 <Image src={githubImage} alt="" unoptimized />
                 <h6 className="text-[#00FF5E] uppercase">Github</h6>
@@ -102,7 +102,7 @@ export default function Header() {
           >
             <div className="flex flex-row items-center space-x-1">
               <Image src={githubImage} alt="" unoptimized />
-              <h6 className="text-#00FF5E uppercase">Github</h6>
+              <h6 className="text-[#00FF5E] uppercase">Github</h6>
             </div>
           </Link>
         </div>


### PR DESCRIPTION
This PR fixes minor typos in `header.tsx`:

- Updated incorrect class `row` to `flex-row` in button styling.
- Corrected color class `text-#00FF5E` to `text-[#00FF5E]`.

---

## Checklist

- [ ] resolves #
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests