### PR TITLE
Feat/taproot verify

### DIFF
--- a/packages/engine/src/engine.cairo
+++ b/packages/engine/src/engine.cairo
@@ -66,6 +66,7 @@ pub struct Engine<T> {
     pub last_code_sep: u32,
     // Count number of non-push opcodes
     pub num_ops: u32,
+    //
     pub hash_cache: @HashCache<T>,
 }
 

--- a/packages/engine/src/engine.cairo
+++ b/packages/engine/src/engine.cairo
@@ -106,6 +106,7 @@ pub impl EngineImpl<
     +Drop<I>,
     +Drop<O>,
     +Drop<T>,
+    +Default<T>,
 > of EngineTrait<I, O, T> {
     // Create a new Engine with the given script
     fn new(
@@ -484,6 +485,7 @@ pub impl EngineInternalImpl<
     +Drop<I>,
     +Drop<O>,
     +Drop<T>,
+    +Default<T>,
 > of EngineInternalTrait<I, O, T> {
     fn pull_data(ref self: Engine<T>, len: usize) -> Result<ByteArray, felt252> {
         let script = *(self.scripts[self.script_idx]);
@@ -652,7 +654,7 @@ pub impl EngineInternalImpl<
 
             if witness_len == 1 {
                 TaprootContextImpl::verify_taproot_spend(
-                    @self.witness_program, witness[0], self.transaction, self.tx_idx
+                    ref self, @self.witness_program, witness[0], self.transaction, self.tx_idx
                 )?;
                 self.taproot_context.must_succeed = true;
                 return Result::Ok(());

--- a/packages/engine/src/engine.cairo
+++ b/packages/engine/src/engine.cairo
@@ -41,7 +41,7 @@ pub struct Engine<T> {
     // Amount of the input being spent
     pub amount: i64,
     // The script to execute
-    scripts: Array<@ByteArray>,
+    pub scripts: Array<@ByteArray>,
     // Index of the current script being executed
     script_idx: usize,
     // Program counter within the current script
@@ -66,6 +66,7 @@ pub struct Engine<T> {
     pub last_code_sep: u32,
     // Count number of non-push opcodes
     pub num_ops: u32,
+    pub hash_cache: @HashCache<T>,
 }
 
 // TODO: SigCache
@@ -146,6 +147,7 @@ pub impl EngineImpl<
             saved_first_stack: array![].span(),
             last_code_sep: 0,
             num_ops: 0,
+            hash_cache: hash_cache,
         };
 
         if engine.has_flag(ScriptFlags::ScriptVerifyCleanStack)

--- a/packages/engine/src/errors.cairo
+++ b/packages/engine/src/errors.cairo
@@ -37,6 +37,8 @@ pub mod Error {
     pub const TAPROOT_EMPTY_PUBKEY: felt252 = 'Empty pubkey in taproot script';
     pub const TAPROOT_INVALID_CONTROL_BLOCK: felt252 = 'Invalid control block';
     pub const TAPROOT_INVALID_SIG: felt252 = 'Invalid signature in tap script';
+    pub const TAPROOT_INVALID_SIGHASH_TYPE: felt252 = 'Invalid taproot sighash type';
+    pub const TAPROOT_INVALID_SIGHASH_MIDSTATE: felt252 = 'Invalid taproot sighash midstat';
     pub const TAPROOT_PARITY_MISMATCH: felt252 = 'Parity mismatch in tap script';
     pub const TAPROOT_INVALID_MERKLE_PROOF: felt252 = 'Invalid taproot merkle proof';
     pub const DISCOURAGE_OP_SUCCESS: felt252 = 'OP_SUCCESS is discouraged';
@@ -47,9 +49,10 @@ pub mod Error {
     pub const SCRIPT_ERR_SIG_DER: felt252 = 'Signature DER error';
     pub const PUBKEYTYPE: felt252 = 'Unsupported public key type';
     pub const SIG_HIGH_S: felt252 = 'Sig not canonical high S value';
-    pub const SIG_HASHTYPE: felt252 = 'invalid hash type';
+    pub const SIG_HASHTYPE: felt252 = 'Invalid hash type';
     pub const INVALID_PUBKEY_LEN: felt252 = 'Invalid public key length';
     pub const NEGATIVE_LOCKTIME: felt252 = 'Stack top is negative';
+    pub const INVALID_INDEX_INPUTS: felt252 = 'Invalid index for inputs';
 }
 
 pub fn byte_array_err(err: felt252) -> ByteArray {

--- a/packages/engine/src/hash_cache.cairo
+++ b/packages/engine/src/hash_cache.cairo
@@ -6,6 +6,7 @@ use shinigami_utils::{
 };
 use core::sha256::compute_sha256_byte_array;
 use crate::signature::utils::is_witness_v1_pub_key_hash;
+use crate::engine::Engine;
 
 #[derive(Clone, Copy, Drop, Default)]
 pub struct SegwitSigHashMidstate {
@@ -31,7 +32,7 @@ pub trait SigHashMidstateTrait<
     +EngineTransactionOutputTrait<O>,
     +EngineTransactionTrait<T, I, O>
 > {
-    fn new(transaction: @T) -> TxSigHashes;
+    fn new(transaction: @T, engine: @Engine<T>) -> TxSigHashes;
 }
 
 
@@ -58,7 +59,7 @@ pub impl SigHashMidstateImpl<
         T, I, O, IEngineTransactionInput, IEngineTransactionOutput
     >
 > of SigHashMidstateTrait<I, O, T> {
-    fn new(transaction: @T) -> TxSigHashes {
+    fn new(transaction: @T, engine: @Engine<T>) -> TxSigHashes {
         let mut hasV0Inputs = false;
         let mut hasV1Inputs = false;
 

--- a/packages/engine/src/hash_cache.cairo
+++ b/packages/engine/src/hash_cache.cairo
@@ -4,7 +4,6 @@ use crate::transaction::{
 use shinigami_utils::{bytecode::{write_var_int}, hash::{hash_to_u256, sha256_u256, simple_sha256},};
 use core::sha256::compute_sha256_byte_array;
 use crate::signature::utils::is_witness_v1_pub_key_hash;
-use crate::engine::Engine;
 use core::dict::Felt252Dict;
 
 // SegwitSigHashMidstate is the sighash midstate used in the base segwit
@@ -35,7 +34,7 @@ pub trait SigHashMidstateTrait<
     +EngineTransactionOutputTrait<O>,
     +EngineTransactionTrait<T, I, O>
 > {
-    fn new(transaction: @T, engine: @Engine<T>) -> TxSigHashes;
+    fn new(transaction: @T) -> TxSigHashes;
     fn calc_hash_inputs_amount(transaction: @T) -> u256;
     fn calc_hash_input_scripts(transaction: @T) -> u256;
 }
@@ -58,7 +57,7 @@ pub impl SigHashMidstateImpl<
         T, I, O, IEngineTransactionInput, IEngineTransactionOutput
     >
 > of SigHashMidstateTrait<I, O, T> {
-    fn new(transaction: @T, engine: @Engine<T>) -> TxSigHashes {
+    fn new(transaction: @T) -> TxSigHashes {
         let mut hasV0Inputs = false;
         let mut hasV1Inputs = false;
 

--- a/packages/engine/src/hash_cache.cairo
+++ b/packages/engine/src/hash_cache.cairo
@@ -11,6 +11,15 @@ pub struct SegwitSigHashMidstate {
     pub hash_outputs_v0: u256
 }
 
+#[derive(Clone, Copy, Drop, Default)]
+pub struct TaprootSigHashMidState {
+    pub hash_prevouts_v1: u256,
+    pub hash_sequence_v1: u256,
+    pub hash_outputs_v1: u256,
+    pub hash_input_scripts_v1: u256,
+    pub hash_input_amounts_v1: u256
+}
+
 pub trait SigHashMidstateTrait<
     I,
     O,
@@ -70,7 +79,7 @@ pub trait SigCacheTrait<S> {
 }
 
 // TODO
-#[derive(Drop)]
+#[derive(Drop, Default)]
 pub struct HashCache<T> {}
 
 // HashCache caches the midstate of segwit v0 and v1 sighashes

--- a/packages/engine/src/hash_cache.cairo
+++ b/packages/engine/src/hash_cache.cairo
@@ -4,7 +4,7 @@ use crate::transaction::{
 use shinigami_utils::bytecode::write_var_int;
 use shinigami_utils::hash::double_sha256;
 
-#[derive(Clone, Copy, Drop)]
+#[derive(Clone, Copy, Drop, Default)]
 pub struct SegwitSigHashMidstate {
     pub hash_prevouts_v0: u256,
     pub hash_sequence_v0: u256,
@@ -28,7 +28,14 @@ pub trait SigHashMidstateTrait<
     +EngineTransactionOutputTrait<O>,
     +EngineTransactionTrait<T, I, O>
 > {
-    fn new(transaction: @T) -> SegwitSigHashMidstate;
+    fn new(transaction: @T) -> TxSigHashes;
+    // fn new_taproot(transaction: @T) -> TaprootSigHashMidState;
+}
+
+#[derive(Drop)]
+pub enum TxSigHashes {
+    Segwit: @SegwitSigHashMidstate,
+    Taproot: @TaprootSigHashMidState
 }
 
 pub impl SigHashMidstateImpl<
@@ -41,7 +48,7 @@ pub impl SigHashMidstateImpl<
         T, I, O, IEngineTransactionInput, IEngineTransactionOutput
     >
 > of SigHashMidstateTrait<I, O, T> {
-    fn new(transaction: @T) -> SegwitSigHashMidstate {
+    fn new(transaction: @T) -> TxSigHashes {
         let mut prevouts_v0_bytes: ByteArray = "";
         let inputs = transaction.get_transaction_inputs();
         for input in inputs {
@@ -61,12 +68,51 @@ pub impl SigHashMidstateImpl<
             write_var_int(ref outputs_v0_bytes, output.get_publickey_script().len().into());
             outputs_v0_bytes.append(output.get_publickey_script());
         };
-        SegwitSigHashMidstate {
-            hash_prevouts_v0: double_sha256(@prevouts_v0_bytes),
-            hash_sequence_v0: double_sha256(@sequence_v0_bytes),
-            hash_outputs_v0: double_sha256(@outputs_v0_bytes)
-        }
+        return TxSigHashes::Segwit(
+            @SegwitSigHashMidstate {
+                hash_prevouts_v0: double_sha256(@prevouts_v0_bytes),
+                hash_sequence_v0: double_sha256(@sequence_v0_bytes),
+                hash_outputs_v0: double_sha256(@outputs_v0_bytes)
+            }
+        );
     }
+    // fn new_taproot(transaction: @T) -> TaprootSigHashMidState {
+//     let mut prevouts_v1_bytes: ByteArray = "";
+//     let inputs = transaction.get_transaction_inputs();
+//     for input in inputs {
+//         let txid = input.get_prevout_txid();
+//         prevouts_v1_bytes.append_word(txid.high.into(), 16);
+//         prevouts_v1_bytes.append_word(txid.low.into(), 16);
+//         prevouts_v1_bytes.append_word_rev(input.get_prevout_vout().into(), 4);
+//     };
+//     let mut sequence_v1_bytes: ByteArray = "";
+//     for input in inputs {
+//         sequence_v1_bytes.append_word_rev(input.get_sequence().into(), 4);
+//     };
+//     let mut outputs_v1_bytes: ByteArray = "";
+//     let outputs = transaction.get_transaction_outputs();
+//     for output in outputs {
+//         outputs_v1_bytes.append_word_rev(output.get_value().into(), 8);
+//         write_var_int(ref outputs_v1_bytes, output.get_publickey_script().len().into());
+//         outputs_v1_bytes.append(output.get_publickey_script());
+//     };
+//     let mut input_scripts_v1_bytes: ByteArray = "";
+//     for input in inputs {
+//         write_var_int(ref input_scripts_v1_bytes, input.get_script().len().into());
+//         input_scripts_v1_bytes.append(input.get_script());
+//     };
+//     let mut input_amounts_v1_bytes: ByteArray = "";
+//     for input in inputs {
+//         input_amounts_v1_bytes.append_word_rev(input.get_amount().into(), 8);
+//     };
+//     TaprootSigHashMidState {
+//         hash_prevouts_v1: double_sha256(@prevouts_v1_bytes),
+//         hash_sequence_v1: double_sha256(@sequence_v1_bytes),
+//         hash_outputs_v1: double_sha256(@outputs_v1_bytes),
+//         hash_input_scripts_v1: double_sha256(@input_scripts_v1_bytes),
+//         hash_input_amounts_v1: double_sha256(@input_amounts_v1_bytes)
+//     }
+// }
 }
 
 // SigCache implements an Schnorr+ECDSA signature verification cache. Only valid signatures will be

--- a/packages/engine/src/hash_tag.cairo
+++ b/packages/engine/src/hash_tag.cairo
@@ -1,5 +1,5 @@
 use shinigami_utils::bytecode::hex_to_bytecode;
-use shinigami_utils::hash::sha256_byte_array;
+use shinigami_utils::hash::{simple_sha256, sha256_byte_array};
 
 #[derive(Drop)]
 pub enum HashTag {
@@ -29,7 +29,7 @@ pub enum HashTag {
 // TaggedHash implements the tagged hash scheme described in BIP-340. We use
 // sha-256 to bind a message hash to a specific context using a tag:
 // sha256(sha256(tag) || sha256(tag) || msg).
-pub fn tagged_hash(tag: HashTag, msg: @ByteArray) -> ByteArray {
+pub fn tagged_hash(tag: HashTag, msg: @ByteArray) -> u256 {
     // Check if we have precomputed tag to avoid an extra sha256
     let mut sha_tag: ByteArray = "";
     match tag {
@@ -82,5 +82,5 @@ pub fn tagged_hash(tag: HashTag, msg: @ByteArray) -> ByteArray {
     let mut h: ByteArray = sha_tag.clone();
     h.append(@sha_tag);
     h.append(msg);
-    return sha256_byte_array(@h);
+    return simple_sha256(@h);
 }

--- a/packages/engine/src/lib.cairo
+++ b/packages/engine/src/lib.cairo
@@ -25,6 +25,7 @@ pub use scriptnum::ScriptNum;
 pub mod flags;
 pub mod signature {
     pub mod signature;
+    pub mod taproot_signature;
     pub mod sighash;
     pub mod constants;
     pub mod utils;

--- a/packages/engine/src/opcodes/constants.cairo
+++ b/packages/engine/src/opcodes/constants.cairo
@@ -13,6 +13,7 @@ pub fn opcode_false<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt252> {
 pub fn opcode_push_data<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -33,6 +34,7 @@ pub fn opcode_push_data<
 pub fn opcode_push_data_x<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,

--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -120,11 +120,10 @@ pub fn opcode_checksig<
             return Result::Err(Error::TAPROOT_EMPTY_PUBKEY);
         }
 
-        // TODO: Errors or false?
-        let mut verifier = TaprootSigVerifierTrait::<
+        let verifier = TaprootSigVerifierTrait::<
             I, O, T
         >::new_base(@full_sig_bytes, @pk_bytes, ref engine)?;
-        is_valid = TaprootSigVerifierTrait::<I, O, T>::verify(verifier);
+        is_valid = TaprootSigVerifierTrait::<I, O, T>::verify(verifier).is_ok();
     }
 
     if !is_valid && @engine.use_taproot == @true {
@@ -422,9 +421,7 @@ pub fn opcode_checksigadd<
     let mut verifier = TaprootSigVerifierTrait::<
         I, O, T
     >::new(@sig_bytes, @pk_bytes, engine.taproot_context.annex, ref engine)?;
-    if !(TaprootSigVerifierTrait::<I, O, T>::verify(verifier)) {
-        return Result::Err(Error::TAPROOT_INVALID_SIG);
-    }
+    TaprootSigVerifierTrait::<I, O, T>::verify(verifier)?;
 
     engine.dstack.push_int(n + 1);
     Result::Ok(())

--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -259,7 +259,7 @@ pub fn opcode_checkmultisig<
         let amount = engine.amount;
 
         if engine.is_witness_active(BASE_SEGWIT_VERSION) {
-            let sig_hashes = SigHashMidstateTrait::new(transaction, @engine);
+            let sig_hashes = SigHashMidstateTrait::new(transaction);
             sig_hash =
                 sighash::calc_witness_signature_hash(
                     @script, sig_hashes, hash_type, transaction, tx_idx, amount

--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -6,8 +6,9 @@ use crate::stack::ScriptStackTrait;
 use crate::flags::ScriptFlags;
 use crate::signature::signature;
 use crate::signature::sighash;
-use crate::signature::signature::{
-    BaseSigVerifierTrait, TaprootSigVerifierTrait, BaseSegwitSigVerifierTrait
+use crate::signature::{
+    signature::{BaseSigVerifierTrait, BaseSegwitSigVerifierTrait},
+    taproot_signature::{TaprootSigVerifierTrait, TaprootSigVerifierImpl, TaprootSigVerifier}
 };
 use starknet::secp256_trait::{is_valid_signature};
 use shinigami_utils::hash::{sha256_byte_array, double_sha256_bytearray};
@@ -119,10 +120,10 @@ pub fn opcode_checksig<
         }
 
         // TODO: Errors or false?
-        let mut verifier = TaprootSigVerifierTrait::<
-            T
-        >::new_base(@full_sig_bytes, @pk_bytes, ref engine)?;
-        is_valid = TaprootSigVerifierTrait::<T>::verify(ref verifier);
+        let mut verifier = TaprootSigVerifierTrait::new_base(
+            @full_sig_bytes, @pk_bytes, ref engine
+        )?;
+        is_valid = TaprootSigVerifierTrait::<I, O, T>::verify(ref verifier);
     }
 
     if !is_valid && @engine.use_taproot == @true {
@@ -414,7 +415,7 @@ pub fn opcode_checksigadd<
 
     let mut verifier = TaprootSigVerifierTrait::<
         T
-    >::new(@sig_bytes, @pk_bytes, engine.taproot_context.annex)?;
+    >::new(@sig_bytes, @pk_bytes, engine.taproot_context.annex, ref engine)?;
     if !(TaprootSigVerifierTrait::<T>::verify(ref verifier)) {
         return Result::Err(Error::TAPROOT_INVALID_SIG);
     }

--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -8,7 +8,7 @@ use crate::signature::signature;
 use crate::signature::sighash;
 use crate::signature::{
     signature::{BaseSigVerifierTrait, BaseSegwitSigVerifierTrait},
-    taproot_signature::{TaprootSigVerifierTrait, TaprootSigVerifierImpl, TaprootSigVerifier}
+    taproot_signature::{TaprootSigVerifierTrait, TaprootSigVerifierImpl}
 };
 use starknet::secp256_trait::{is_valid_signature};
 use shinigami_utils::hash::{sha256_byte_array, double_sha256_bytearray};
@@ -263,7 +263,7 @@ pub fn opcode_checkmultisig<
             let sig_hashes = SigHashMidstateTrait::new(transaction);
             sig_hash =
                 sighash::calc_witness_signature_hash(
-                    @script, @sig_hashes, hash_type, transaction, tx_idx, amount
+                    @script, sig_hashes, hash_type, transaction, tx_idx, amount
                 );
         } else {
             sig_hash = sighash::calc_signature_hash(@script, hash_type, transaction, tx_idx);

--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -53,6 +53,7 @@ pub fn opcode_ripemd160<T, +Drop<T>>(ref engine: Engine<T>) -> Result<(), felt25
 pub fn opcode_checksig<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -120,9 +121,9 @@ pub fn opcode_checksig<
         }
 
         // TODO: Errors or false?
-        let mut verifier = TaprootSigVerifierTrait::new_base(
-            @full_sig_bytes, @pk_bytes, ref engine
-        )?;
+        let mut verifier = TaprootSigVerifierTrait::<
+            I, O, T
+        >::new_base(@full_sig_bytes, @pk_bytes, ref engine)?;
         is_valid = TaprootSigVerifierTrait::<I, O, T>::verify(ref verifier);
     }
 
@@ -140,11 +141,12 @@ pub fn opcode_checksig<
 pub fn opcode_checkmultisig<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
-    impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
     O,
     +Drop<O>,
+    impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
     impl IEngineTransactionOutputTrait: EngineTransactionOutputTrait<O>,
     impl IEngineTransactionTrait: EngineTransactionTrait<
         T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
@@ -312,6 +314,7 @@ pub fn opcode_codeseparator<
         T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
     >,
     +Drop<T>,
+    +Default<T>,
     +Drop<I>,
     +Drop<O>,
 >(
@@ -333,6 +336,7 @@ pub fn opcode_codeseparator<
 pub fn opcode_checksigverify<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -353,6 +357,7 @@ pub fn opcode_checksigverify<
 pub fn opcode_checkmultisigverify<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -387,6 +392,7 @@ pub fn opcode_checksigadd<
         T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
     >,
     +Drop<T>,
+    +Default<T>,
     +Drop<I>,
     +Drop<O>,
 >(
@@ -414,9 +420,9 @@ pub fn opcode_checksigadd<
     }
 
     let mut verifier = TaprootSigVerifierTrait::<
-        T
+        I, O, T
     >::new(@sig_bytes, @pk_bytes, engine.taproot_context.annex, ref engine)?;
-    if !(TaprootSigVerifierTrait::<T>::verify(ref verifier)) {
+    if !(TaprootSigVerifierTrait::<I, O, T>::verify(ref verifier)) {
         return Result::Err(Error::TAPROOT_INVALID_SIG);
     }
 

--- a/packages/engine/src/opcodes/crypto.cairo
+++ b/packages/engine/src/opcodes/crypto.cairo
@@ -124,7 +124,7 @@ pub fn opcode_checksig<
         let mut verifier = TaprootSigVerifierTrait::<
             I, O, T
         >::new_base(@full_sig_bytes, @pk_bytes, ref engine)?;
-        is_valid = TaprootSigVerifierTrait::<I, O, T>::verify(ref verifier);
+        is_valid = TaprootSigVerifierTrait::<I, O, T>::verify(verifier);
     }
 
     if !is_valid && @engine.use_taproot == @true {
@@ -260,7 +260,7 @@ pub fn opcode_checkmultisig<
         let amount = engine.amount;
 
         if engine.is_witness_active(BASE_SEGWIT_VERSION) {
-            let sig_hashes = SigHashMidstateTrait::new(transaction);
+            let sig_hashes = SigHashMidstateTrait::new(transaction, @engine);
             sig_hash =
                 sighash::calc_witness_signature_hash(
                     @script, sig_hashes, hash_type, transaction, tx_idx, amount
@@ -422,7 +422,7 @@ pub fn opcode_checksigadd<
     let mut verifier = TaprootSigVerifierTrait::<
         I, O, T
     >::new(@sig_bytes, @pk_bytes, engine.taproot_context.annex, ref engine)?;
-    if !(TaprootSigVerifierTrait::<I, O, T>::verify(ref verifier)) {
+    if !(TaprootSigVerifierTrait::<I, O, T>::verify(verifier)) {
         return Result::Err(Error::TAPROOT_INVALID_SIG);
     }
 

--- a/packages/engine/src/opcodes/flow.cairo
+++ b/packages/engine/src/opcodes/flow.cairo
@@ -10,6 +10,7 @@ use crate::errors::Error;
 pub fn opcode_nop<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -38,6 +39,7 @@ const op_cond_skip: u8 = 2;
 pub fn opcode_if<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -67,6 +69,7 @@ pub fn opcode_if<
 pub fn opcode_notif<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,

--- a/packages/engine/src/opcodes/locktime.cairo
+++ b/packages/engine/src/opcodes/locktime.cairo
@@ -31,6 +31,7 @@ fn verify_locktime(tx_locktime: i64, threshold: i64, stack_locktime: i64) -> Res
 pub fn opcode_checklocktimeverify<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -81,6 +82,7 @@ pub fn opcode_checklocktimeverify<
 pub fn opcode_checksequenceverify<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,

--- a/packages/engine/src/opcodes/opcodes.cairo
+++ b/packages/engine/src/opcodes/opcodes.cairo
@@ -201,6 +201,7 @@ pub mod Opcode {
     pub fn execute<
         T,
         +Drop<T>,
+        +Default<T>,
         I,
         +Drop<I>,
         impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,

--- a/packages/engine/src/signature/constants.cairo
+++ b/packages/engine/src/signature/constants.cairo
@@ -41,6 +41,8 @@ pub const HASH_TYPE_LEN: usize = 1;
 //including the version byte and the public key hash, ensuring correct data formatting and inclusion
 //in SegWit transactions.
 pub const WITNESS_V0_PUB_KEY_HASH_LEN: usize = 22;
+//
+pub const WITNESS_V1_PUB_KEY_HASH_LEN: usize = 34;
 
 pub const MAX_U128: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 pub const MAX_U32: u32 = 0xFFFFFFFF;

--- a/packages/engine/src/signature/sighash.cairo
+++ b/packages/engine/src/signature/sighash.cairo
@@ -6,6 +6,7 @@ use crate::signature::constants;
 use crate::signature::utils::{
     remove_opcodeseparator, transaction_procedure, is_witness_pub_key_hash
 };
+use crate::transaction::{EngineTransactionOutput};
 use shinigami_utils::bytecode::write_var_int;
 use shinigami_utils::hash::{sha256_byte_array, double_sha256};
 use crate::opcodes::opcodes::Opcode;
@@ -248,9 +249,29 @@ fn is_valid_taproot_sighash(hash_type: u32) -> bool {
     }
 }
 
-fn calc_taproot_signature_hash() -> u256 {
-    0 // TODO
+pub fn calc_taproot_signature_hash<
+    T,
+    +Drop<T>,
+    I,
+    +Drop<I>,
+    O,
+    +Drop<O>,
+    impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
+    impl IEngineTransactionOutputTrait: EngineTransactionOutputTrait<O>,
+    impl IEngineTransactionTrait: EngineTransactionTrait<
+        T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
+    >
+>(
+    sigHashes: TxSigHashes,
+    h_type: u32,
+    transaction: @T,
+    idx: u32,
+    prev_output: EngineTransactionOutput,
+    // sig_hash_opts: TaprootSigHashOpts
+) -> u256 {
+    1
 }
+
 
 fn calc_tapscript_signature_hash() -> u256 {
     0 // TODO

--- a/packages/engine/src/signature/sighash.cairo
+++ b/packages/engine/src/signature/sighash.cairo
@@ -6,10 +6,10 @@ use crate::signature::constants;
 use crate::signature::utils::{
     remove_opcodeseparator, transaction_procedure, is_witness_pub_key_hash
 };
-use crate::hash_cache::SegwitSigHashMidstate;
 use shinigami_utils::bytecode::write_var_int;
 use shinigami_utils::hash::{sha256_byte_array, double_sha256};
 use crate::opcodes::opcodes::Opcode;
+use crate::hash_cache::{TxSigHashes, SegwitSigHashMidstate};
 
 // Calculates the signature hash for specified transaction data and hash type.
 pub fn calc_signature_hash<
@@ -66,14 +66,20 @@ pub fn calc_witness_signature_hash<
     +Drop<T>
 >(
     sub_script: @ByteArray,
-    sig_hashes: @SegwitSigHashMidstate,
+    sig_hashes_enum: TxSigHashes,
     hash_type: u32,
     transaction: @T,
     tx_idx: u32,
     amount: i64
 ) -> u256 {
-    // TODO: Bounds check?
+    let mut sig_hashes: @SegwitSigHashMidstate = Default::default();
+    match sig_hashes_enum {
+        TxSigHashes::Segwit(segwit_midstate) => { sig_hashes = segwit_midstate; },
+        // Handle error ?
+        _ => { return 0; }
+    }
 
+    // TODO: Bounds check?
     let mut sig_hash_bytes: ByteArray = "";
     sig_hash_bytes.append_word_rev(transaction.get_version().into(), 4);
 

--- a/packages/engine/src/signature/signature.cairo
+++ b/packages/engine/src/signature/signature.cairo
@@ -6,13 +6,12 @@ use starknet::SyscallResultTrait;
 use starknet::secp256_trait::{Secp256Trait, Signature, is_valid_signature};
 use starknet::secp256k1::{Secp256k1Point};
 use crate::flags::ScriptFlags;
-use crate::hash_cache::{SigHashMidstateTrait, TaprootSigHashMidState};
+use crate::hash_cache::{SigHashMidstateTrait};
 use shinigami_utils::byte_array::u256_from_byte_array_with_offset;
 use crate::signature::{sighash, constants};
 use crate::errors::Error;
 use shinigami_utils::byte_array::{sub_byte_array};
 use crate::parser;
-use crate::transaction::{EngineTransaction, EngineTransactionInput, EngineTransactionOutput};
 
 //`BaseSigVerifier` is used to verify ECDSA signatures encoded in DER or BER format (pre-SegWit sig)
 #[derive(Drop)]
@@ -106,7 +105,7 @@ impl BaseSegwitSigVerifierImpl<
         let sig_hashes = SigHashMidstateTrait::new(vm.transaction);
         let sig_hash: u256 = sighash::calc_witness_signature_hash::<
             I, O, T
-        >(@self.sub_script, @sig_hashes, self.hash_type, vm.transaction, vm.tx_idx, vm.amount);
+        >(@self.sub_script, sig_hashes, self.hash_type, vm.transaction, vm.tx_idx, vm.amount);
 
         is_valid_signature(sig_hash, self.sig.r, self.sig.s, self.pub_key)
     }

--- a/packages/engine/src/signature/signature.cairo
+++ b/packages/engine/src/signature/signature.cairo
@@ -102,7 +102,7 @@ impl BaseSegwitSigVerifierImpl<
     +Drop<T>
 > of BaseSegwitSigVerifierTrait<I, O, T> {
     fn verify(ref self: BaseSigVerifier, ref vm: Engine<T>) -> bool {
-        let sig_hashes = SigHashMidstateTrait::new(vm.transaction, @vm);
+        let sig_hashes = SigHashMidstateTrait::new(vm.transaction);
         let sig_hash: u256 = sighash::calc_witness_signature_hash::<
             I, O, T
         >(@self.sub_script, sig_hashes, self.hash_type, vm.transaction, vm.tx_idx, vm.amount);

--- a/packages/engine/src/signature/signature.cairo
+++ b/packages/engine/src/signature/signature.cairo
@@ -56,7 +56,8 @@ impl BaseSigVerifierImpl<
     >,
     +Drop<I>,
     +Drop<O>,
-    +Drop<T>
+    +Drop<T>,
+    +Default<T>,
 > of BaseSigVerifierTrait<I, O, T> {
     fn new(
         ref vm: Engine<T>, sig_bytes: @ByteArray, pk_bytes: @ByteArray
@@ -137,6 +138,7 @@ pub fn compare_data(script: @ByteArray, sig_bytes: @ByteArray, i: u32, push_data
 pub fn check_hash_type_encoding<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -177,6 +179,7 @@ pub fn check_hash_type_encoding<
 pub fn check_signature_encoding<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -332,6 +335,7 @@ fn is_supported_pub_key_type(pk_bytes: @ByteArray) -> bool {
 pub fn check_pub_key_encoding<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
@@ -488,6 +492,7 @@ pub fn parse_signature(sig_bytes: @ByteArray) -> Result<Signature, felt252> {
 pub fn parse_base_sig_and_pk<
     T,
     +Drop<T>,
+    +Default<T>,
     I,
     +Drop<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,

--- a/packages/engine/src/signature/signature.cairo
+++ b/packages/engine/src/signature/signature.cairo
@@ -102,7 +102,7 @@ impl BaseSegwitSigVerifierImpl<
     +Drop<T>
 > of BaseSegwitSigVerifierTrait<I, O, T> {
     fn verify(ref self: BaseSigVerifier, ref vm: Engine<T>) -> bool {
-        let sig_hashes = SigHashMidstateTrait::new(vm.transaction);
+        let sig_hashes = SigHashMidstateTrait::new(vm.transaction, @vm);
         let sig_hash: u256 = sighash::calc_witness_signature_hash::<
             I, O, T
         >(@self.sub_script, sig_hashes, self.hash_type, vm.transaction, vm.tx_idx, vm.amount);

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -8,6 +8,7 @@ use crate::flags::ScriptFlags;
 use crate::signature::{constants, signature::parse_pub_key};
 use crate::transaction::{EngineTransactionOutput};
 use shinigami_utils::byte_array::u256_from_byte_array_with_offset;
+use crate::hash_cache::{TxSigHashes};
 
 pub const SCHNORR_SIGNATURE_LEN: usize = 64;
 
@@ -43,7 +44,6 @@ pub fn schnorr_parse_signature(sig_bytes: @ByteArray) -> Result<(Signature, u32)
     )
 }
 
-
 #[derive(Drop)]
 pub struct TaprootSigVerifier<T> {
     // public key as a point on the secp256k1 curve, used to verify the signature
@@ -65,7 +65,7 @@ pub struct TaprootSigVerifier<T> {
     //
     // sigCache: SigCache TODO?
     //
-    // hashCache: TaprootSigHashMidState,
+    hashCache: TxSigHashes,
     // annex data used for taproot verification
     annex: @ByteArray,
 }
@@ -115,7 +115,7 @@ pub impl TaprootSigVerifierImpl<
             tx: @Default::default(),
             inputIndex: 0,
             prevOuts: Default::<EngineTransactionOutput>::default(),
-            // hashCache: Default::<TaprootSigHashMidState>::default(),
+            hashCache: Default::default(),
             annex: @""
         }
     }
@@ -143,6 +143,7 @@ pub impl TaprootSigVerifierImpl<
                 inputIndex: engine.tx_idx,
                 prevOuts: prevOutput,
                 // hashCache: engine.hash_cache,
+                hashCache: Default::default(),
                 annex
             }
         )

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -97,11 +97,9 @@ pub impl TaprootSigVerifierImpl<
     +Default<T>,
     I,
     +Drop<I>,
-    // +Default<I>,
     impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
     O,
     +Drop<O>,
-    // +Default<O>,
     impl IEngineTransactionOutputTrait: EngineTransactionOutputTrait<O>,
     impl IEngineTransactionTrait: EngineTransactionTrait<
         T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -5,12 +5,9 @@ use crate::transaction::{
 use starknet::secp256_trait::{Secp256Trait, Signature};
 use starknet::secp256k1::{Secp256k1Point};
 use crate::flags::ScriptFlags;
+use crate::signature::{constants, signature::parse_pub_key};
+use crate::transaction::{EngineTransactionOutput};
 use shinigami_utils::byte_array::u256_from_byte_array_with_offset;
-use crate::signature::{sighash, constants, signature::parse_pub_key};
-use crate::errors::Error;
-use shinigami_utils::byte_array::{sub_byte_array};
-use crate::parser;
-use crate::transaction::{EngineTransaction, EngineTransactionInput, EngineTransactionOutput};
 
 pub const SCHNORR_SIGNATURE_LEN: usize = 64;
 
@@ -115,7 +112,6 @@ pub impl TaprootSigVerifierImpl<
             sig_bytes: @"",
             pk_bytes: @"",
             hash_type: 0,
-            // tx: @Default::<T>::default(),
             tx: @Default::default(),
             inputIndex: 0,
             prevOuts: Default::<EngineTransactionOutput>::default(),
@@ -130,13 +126,11 @@ pub impl TaprootSigVerifierImpl<
         let pub_key = parse_schnorr_pub_key(pk_bytes)?;
         let (sig, hash_type) = schnorr_parse_signature(sig_bytes)?;
 
-        // let prevOutput = EngineTransactionOutput {
-        //     value: engine.amount, publickey_script: engine.scripts[1],
-        // };
-
         let prevOutput = EngineTransactionOutput {
             value: engine.amount, publickey_script: (*engine.scripts[1]).clone(),
         };
+
+        // let sig_hashes = SigHashMidstateTrait::new(transaction);
 
         Result::Ok(
             TaprootSigVerifier {

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -1,0 +1,207 @@
+use crate::engine::{Engine, EngineInternalImpl};
+use crate::transaction::{
+    EngineTransactionInputTrait, EngineTransactionOutputTrait, EngineTransactionTrait
+};
+use starknet::SyscallResultTrait;
+use starknet::secp256_trait::{Secp256Trait, Signature, is_valid_signature};
+use starknet::secp256k1::{Secp256k1Point};
+use crate::flags::ScriptFlags;
+use crate::hash_cache::{SigHashMidstateTrait, TaprootSigHashMidState};
+use shinigami_utils::byte_array::u256_from_byte_array_with_offset;
+use crate::signature::{sighash, constants, signature::parse_pub_key};
+use crate::errors::Error;
+use shinigami_utils::byte_array::{sub_byte_array};
+use crate::parser;
+use crate::transaction::{EngineTransaction, EngineTransactionInput, EngineTransactionOutput};
+
+pub const SCHNORR_SIGNATURE_LEN: usize = 64;
+
+pub fn parse_schnorr_pub_key(pk_bytes: @ByteArray) -> Result<Secp256k1Point, felt252> {
+    if pk_bytes.len() == 0 || pk_bytes.len() != 32 {
+        return Result::Err('Invalid schnorr pubkey length');
+    }
+
+    let mut key_compressed: ByteArray = "\02";
+    key_compressed.append(pk_bytes);
+    return parse_pub_key(@key_compressed);
+}
+
+pub fn schnorr_parse_signature(sig_bytes: @ByteArray) -> Result<(Signature, u32), felt252> {
+    let sig_bytes_len = sig_bytes.len();
+    let mut hash_type: u32 = 0;
+    if sig_bytes_len == SCHNORR_SIGNATURE_LEN {
+        hash_type = constants::SIG_HASH_DEFAULT;
+    } else if sig_bytes_len == SCHNORR_SIGNATURE_LEN + 1 && sig_bytes[64] != 0 {
+        hash_type = sig_bytes[64].into();
+    } else {
+        return Result::Err('Invalid taproot signature len');
+    }
+    Result::Ok(
+        (
+            Signature {
+                r: u256_from_byte_array_with_offset(sig_bytes, 0, 32),
+                s: u256_from_byte_array_with_offset(sig_bytes, 32, 32),
+                y_parity: false, // Schnorr signatures don't use y_parity
+            },
+            hash_type
+        )
+    )
+}
+
+
+#[derive(Drop)]
+pub struct TaprootSigVerifier<T> {
+    // public key as a point on the secp256k1 curve, used to verify the signature
+    pub_key: Secp256k1Point,
+    // ECDSA signature
+    sig: Signature,
+    // raw byte array of the signature
+    sig_bytes: @ByteArray,
+    // raw byte array of the public key
+    pk_bytes: @ByteArray,
+    // specifies how the transaction was hashed for signing
+    hash_type: u32,
+    // transaction being verified
+    tx: @T,
+    // index of the input being verified
+    inputIndex: u32,
+    // output being spent
+    prevOuts: EngineTransactionOutput,
+    //
+    // sigCache: SigCache TODO?
+    //
+    // hashCache: TaprootSigHashMidState,
+    // annex data used for taproot verification
+    annex: @ByteArray,
+}
+
+pub impl TaprootSigVerifierDefault<
+    T,
+    +Drop<T>,
+    +Default<T>,
+    // I,
+    // +Default<I>,
+    // +Drop<I>,
+    // impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
+    // O,
+    // +Drop<O>,
+    // +Default<O>,
+    // impl IEngineTransactionOutputTrait: EngineTransactionOutputTrait<O>,
+    // impl IEngineTransactionTrait: EngineTransactionTrait<
+    //     T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
+    // >
+> of Default<TaprootSigVerifier<T>> {
+    fn default() -> TaprootSigVerifier<T> {
+        TaprootSigVerifier {
+            pub_key: Secp256Trait::<Secp256k1Point>::get_generator_point(),
+            sig: Signature { r: 0, s: 0, y_parity: false },
+            sig_bytes: @"",
+            pk_bytes: @"",
+            hash_type: 0,
+            tx: @Default::<T>::default(),
+            inputIndex: 0,
+            prevOuts: Default::<EngineTransactionOutput>::default(),
+            // hashCache: Default::<TaprootSigHashMidState>::default(),
+            annex: @""
+        }
+    }
+}
+
+pub trait TaprootSigVerifierTrait<
+    T,
+    +Drop<T>,
+    +Default<T>,
+    I,
+    +Drop<I>,
+    +Default<I>,
+    impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
+    O,
+    +Drop<O>,
+    +Default<O>,
+    impl IEngineTransactionOutputTrait: EngineTransactionOutputTrait<O>,
+    impl IEngineTransactionTrait: EngineTransactionTrait<
+        T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
+    >
+> {
+    fn new(
+        sig_bytes: @ByteArray, pk_bytes: @ByteArray, annex: @ByteArray, ref engine: Engine<T>
+    ) -> Result<TaprootSigVerifier<T>, felt252>;
+    fn new_base(
+        sig_bytes: @ByteArray, pk_bytes: @ByteArray, ref engine: Engine<T>
+    ) -> Result<TaprootSigVerifier<T>, felt252>;
+    fn verify(ref self: TaprootSigVerifier<T>) -> bool;
+    fn verify_base(ref self: TaprootSigVerifier<T>) -> bool;
+}
+
+pub impl TaprootSigVerifierImpl<
+    T,
+    +Drop<T>,
+    +Default<T>,
+    I,
+    +Drop<I>,
+    +Default<I>,
+    impl IEngineTransactionInputTrait: EngineTransactionInputTrait<I>,
+    O,
+    +Drop<O>,
+    +Default<O>,
+    impl IEngineTransactionOutputTrait: EngineTransactionOutputTrait<O>,
+    impl IEngineTransactionTrait: EngineTransactionTrait<
+        T, I, O, IEngineTransactionInputTrait, IEngineTransactionOutputTrait
+    >
+> of TaprootSigVerifierTrait<T, I, O> {
+    fn new(
+        sig_bytes: @ByteArray, pk_bytes: @ByteArray, annex: @ByteArray, ref engine: Engine<T>
+    ) -> Result<TaprootSigVerifier<T>, felt252> {
+        let pub_key = parse_schnorr_pub_key(pk_bytes)?;
+        let (sig, hash_type) = schnorr_parse_signature(sig_bytes)?;
+
+        // let prevOutput = EngineTransactionOutput {
+        //     value: engine.amount, publickey_script: engine.scripts[1],
+        // };
+
+        let prevOutput = EngineTransactionOutput {
+            value: engine.amount, publickey_script: (*engine.scripts[1]).clone(),
+        };
+
+        Result::Ok(
+            TaprootSigVerifier {
+                pub_key,
+                sig,
+                sig_bytes,
+                pk_bytes,
+                hash_type,
+                tx: engine.transaction,
+                inputIndex: engine.tx_idx,
+                prevOuts: prevOutput,
+                // hashCache: engine.hash_cache,
+                annex
+            }
+        )
+    }
+
+    fn new_base(
+        sig_bytes: @ByteArray, pk_bytes: @ByteArray, ref engine: Engine<T>
+    ) -> Result<TaprootSigVerifier<T>, felt252> {
+        let pk_bytes_len = pk_bytes.len();
+        if pk_bytes_len == 0 {
+            return Result::Err('Taproot empty public key');
+        } else if pk_bytes_len == 32 {
+            return Self::new(sig_bytes, pk_bytes, engine.taproot_context.annex, ref engine);
+        } else {
+            if engine.has_flag(ScriptFlags::ScriptVerifyDiscourageUpgradeablePubkeyType) {
+                return Result::Err('Unknown pub key type');
+            }
+            return Result::Ok(Default::<TaprootSigVerifier<T>>::default());
+        }
+    }
+
+    fn verify(ref self: TaprootSigVerifier<T>) -> bool {
+        // TODO: implement taproot verification
+        return false;
+    }
+
+    fn verify_base(ref self: TaprootSigVerifier<T>) -> bool {
+        // TODO: implement taproot verification
+        return false;
+    }
+}

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -125,7 +125,7 @@ pub impl TaprootSigVerifierImpl<
     ) -> Result<TaprootSigVerifier<T>, felt252> {
         let pub_key = parse_schnorr_pub_key(pk_bytes)?;
         let (sig, hash_type) = schnorr_parse_signature(sig_bytes)?;
-        let sig_hashes = SigHashMidstateTrait::new(engine.transaction, @engine);
+        let sig_hashes = SigHashMidstateTrait::new(engine.transaction);
         let prevOutput = EngineTransactionOutput {
             value: engine.amount, publickey_script: (*engine.scripts[1]).clone(),
         };

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -5,7 +5,8 @@ use crate::transaction::{
 use starknet::secp256_trait::{Secp256Trait, Signature};
 use starknet::secp256k1::{Secp256k1Point};
 use crate::flags::ScriptFlags;
-use crate::signature::{constants, signature::parse_pub_key, sighash};
+use crate::signature::{constants, signature::parse_pub_key};
+use crate::signature::{sighash, sighash::{TaprootSighashOptions, TaprootSighashOptionsTrait}};
 use crate::transaction::{EngineTransactionOutput};
 use shinigami_utils::byte_array::u256_from_byte_array_with_offset;
 use crate::hash_cache::{TxSigHashes};
@@ -164,9 +165,14 @@ pub impl TaprootSigVerifierImpl<
     }
 
     fn verify(self: TaprootSigVerifier<T>) -> bool {
+        let mut opts = TaprootSighashOptionsTrait::new_with_annex(self.annex);
+        // if self.annex.len() != 0 {
+        //     opts.append(TaprootSighashOptionsTrait::new_with_annex(self.annex));
+        // }
+
         let sig_hash: u256 = sighash::calc_taproot_signature_hash::<
             T
-        >(self.hashCache, self.hash_type, self.tx, self.inputIndex, self.prevOuts);
+        >(self.hashCache, self.hash_type, self.tx, self.inputIndex, self.prevOuts, ref opts);
 
         is_valid_schnorr_signature(sig_hash, self.sig, self.pub_key)
     }

--- a/packages/engine/src/signature/taproot_signature.cairo
+++ b/packages/engine/src/signature/taproot_signature.cairo
@@ -5,10 +5,11 @@ use crate::transaction::{
 use starknet::secp256_trait::{Secp256Trait, Signature};
 use starknet::secp256k1::{Secp256k1Point};
 use crate::flags::ScriptFlags;
-use crate::signature::{constants, signature::parse_pub_key};
+use crate::signature::{constants, signature::parse_pub_key, sighash};
 use crate::transaction::{EngineTransactionOutput};
 use shinigami_utils::byte_array::u256_from_byte_array_with_offset;
 use crate::hash_cache::{TxSigHashes};
+use crate::hash_cache::{SigHashMidstateTrait};
 
 pub const SCHNORR_SIGNATURE_LEN: usize = 64;
 
@@ -85,7 +86,7 @@ pub trait TaprootSigVerifierTrait<
     fn new_base(
         sig_bytes: @ByteArray, pk_bytes: @ByteArray, ref engine: Engine<T>
     ) -> Result<TaprootSigVerifier<T>, felt252>;
-    fn verify(ref self: TaprootSigVerifier<T>) -> bool;
+    fn verify(self: TaprootSigVerifier<T>) -> bool;
     fn verify_base(ref self: TaprootSigVerifier<T>) -> bool;
 }
 
@@ -125,12 +126,10 @@ pub impl TaprootSigVerifierImpl<
     ) -> Result<TaprootSigVerifier<T>, felt252> {
         let pub_key = parse_schnorr_pub_key(pk_bytes)?;
         let (sig, hash_type) = schnorr_parse_signature(sig_bytes)?;
-
+        let sig_hashes = SigHashMidstateTrait::new(engine.transaction, @engine);
         let prevOutput = EngineTransactionOutput {
             value: engine.amount, publickey_script: (*engine.scripts[1]).clone(),
         };
-
-        // let sig_hashes = SigHashMidstateTrait::new(transaction);
 
         Result::Ok(
             TaprootSigVerifier {
@@ -142,8 +141,7 @@ pub impl TaprootSigVerifierImpl<
                 tx: engine.transaction,
                 inputIndex: engine.tx_idx,
                 prevOuts: prevOutput,
-                // hashCache: engine.hash_cache,
-                hashCache: Default::default(),
+                hashCache: sig_hashes,
                 annex
             }
         )
@@ -165,13 +163,24 @@ pub impl TaprootSigVerifierImpl<
         }
     }
 
-    fn verify(ref self: TaprootSigVerifier<T>) -> bool {
-        // TODO: implement taproot verification
-        return false;
+    fn verify(self: TaprootSigVerifier<T>) -> bool {
+        let sig_hash: u256 = sighash::calc_taproot_signature_hash::<
+            T
+        >(self.hashCache, self.hash_type, self.tx, self.inputIndex, self.prevOuts);
+
+        is_valid_schnorr_signature(sig_hash, self.sig, self.pub_key)
     }
 
     fn verify_base(ref self: TaprootSigVerifier<T>) -> bool {
         // TODO: implement taproot verification
         return false;
     }
+}
+
+pub fn is_valid_schnorr_signature<
+    Secp256Point, +Drop<Secp256Point>, impl Secp256Impl: Secp256Trait<Secp256Point>,
+>(
+    msg_hash: u256, sig: Signature, public_key: Secp256Point
+) -> bool {
+    return false;
 }

--- a/packages/engine/src/signature/utils.cairo
+++ b/packages/engine/src/signature/utils.cairo
@@ -164,3 +164,13 @@ pub fn is_witness_pub_key_hash(script: @ByteArray) -> bool {
     }
     false
 }
+
+// Checks if the given script is a Pay-to-Taproot script.
+pub fn is_witness_v1_pub_key_hash(script: @ByteArray) -> bool {
+    if script.len() == constants::WITNESS_V1_PUB_KEY_HASH_LEN
+        && script[0] == Opcode::OP_1
+        && script[1] == Opcode::OP_DATA_32 {
+        return true;
+    }
+    false
+}

--- a/packages/engine/src/taproot.cairo
+++ b/packages/engine/src/taproot.cairo
@@ -167,7 +167,7 @@ pub impl TaprootContextImpl of TaprootContextTrait {
             T
         >::new(raw_sig, witness_program, annex, ref engine)?;
         let is_valid = TaprootSigVerifierImpl::<T>::verify(verifier);
-        if !is_valid {
+        if is_valid.is_err() {
             return Result::Err(Error::TAPROOT_INVALID_SIG);
         }
         Result::Ok(())

--- a/packages/engine/src/taproot.cairo
+++ b/packages/engine/src/taproot.cairo
@@ -166,7 +166,7 @@ pub impl TaprootContextImpl of TaprootContextTrait {
         let mut verifier = TaprootSigVerifierImpl::<
             T
         >::new(raw_sig, witness_program, annex, ref engine)?;
-        let is_valid = TaprootSigVerifierImpl::<T>::verify(ref verifier);
+        let is_valid = TaprootSigVerifierImpl::<T>::verify(verifier);
         if !is_valid {
             return Result::Err(Error::TAPROOT_INVALID_SIG);
         }

--- a/packages/engine/src/taproot.cairo
+++ b/packages/engine/src/taproot.cairo
@@ -2,8 +2,8 @@ use crate::errors::Error;
 use crate::transaction::{
     EngineTransactionTrait, EngineTransactionInputTrait, EngineTransactionOutputTrait
 };
-use crate::signature::signature::parse_schnorr_pub_key;
-use crate::signature::signature::{TaprootSigVerifierImpl};
+use crate::signature::taproot_signature::parse_schnorr_pub_key;
+use crate::signature::taproot_signature::{TaprootSigVerifierImpl};
 use starknet::secp256k1::{Secp256k1Point};
 
 #[derive(Destruct)]
@@ -160,7 +160,7 @@ pub impl TaprootContextImpl of TaprootContextTrait {
             annex = witness[witness.len() - 1];
         }
 
-        let mut verifier = TaprootSigVerifierImpl::<T>::new(raw_sig, witness_program, annex)?;
+        let mut verifier = TaprootSigVerifierImpl::<T, I, O>::new(raw_sig, witness_program, annex)?;
         let is_valid = TaprootSigVerifierImpl::<T>::verify(ref verifier);
         if !is_valid {
             return Result::Err(Error::TAPROOT_INVALID_SIG);

--- a/packages/engine/src/transaction.cairo
+++ b/packages/engine/src/transaction.cairo
@@ -19,7 +19,7 @@ pub struct EngineTransactionInput {
     pub sequence: u32,
 }
 
-#[derive(Drop, Clone)]
+#[derive(Drop, Clone, Default)]
 pub struct EngineTransactionOutput {
     pub value: i64,
     pub publickey_script: ByteArray,

--- a/packages/engine/src/transaction.cairo
+++ b/packages/engine/src/transaction.cairo
@@ -5,13 +5,13 @@ use shinigami_utils::bit_shifts::shr;
 use shinigami_utils::hash::double_sha256;
 
 // Tracks previous transaction outputs
-#[derive(Drop, Copy)]
+#[derive(Drop, Copy, Default)]
 pub struct EngineOutPoint {
     pub txid: u256,
     pub vout: u32,
 }
 
-#[derive(Drop, Clone)]
+#[derive(Drop, Clone, Default)]
 pub struct EngineTransactionInput {
     pub previous_outpoint: EngineOutPoint,
     pub signature_script: ByteArray,
@@ -27,7 +27,7 @@ pub struct EngineTransactionOutput {
 
 // TODO: Move these EngineTransaction structs to the testing dir after
 // signature::transaction_procedure cleanup
-#[derive(Drop, Clone)]
+#[derive(Drop, Clone, Default)]
 pub struct EngineTransaction {
     pub version: i32,
     pub transaction_inputs: Array<EngineTransactionInput>,

--- a/packages/engine/src/transaction.cairo
+++ b/packages/engine/src/transaction.cairo
@@ -27,7 +27,7 @@ pub struct EngineTransactionOutput {
 
 // TODO: Move these EngineTransaction structs to the testing dir after
 // signature::transaction_procedure cleanup
-#[derive(Drop, Clone, Default)]
+#[derive(Drop, Clone)]
 pub struct EngineTransaction {
     pub version: i32,
     pub transaction_inputs: Array<EngineTransactionInput>,

--- a/packages/utils/src/hash.cairo
+++ b/packages/utils/src/hash.cairo
@@ -31,16 +31,6 @@ pub fn double_sha256_bytearray(byte: @ByteArray) -> ByteArray {
     return sha256_byte_array(@sha256_byte_array(byte));
 }
 
-pub fn hash_to_u256(hash: [u32; 8]) -> u256 {
-    let mut hash_value: u256 = 0;
-    for word in hash.span() {
-        hash_value *= 0x100000000;
-        hash_value = hash_value + (*word).into();
-    };
-
-    hash_value
-}
-
 pub fn simple_sha256(byte: @ByteArray) -> u256 {
     let msg_hash = compute_sha256_byte_array(byte);
     let mut hash_value: u256 = 0;
@@ -66,6 +56,16 @@ pub fn double_sha256(byte: @ByteArray) -> u256 {
             hash_value *= 0x100000000;
             hash_value = hash_value + (*word).into();
         };
+
+    hash_value
+}
+
+pub fn hash_to_u256(hash: [u32; 8]) -> u256 {
+    let mut hash_value: u256 = 0;
+    for word in hash.span() {
+        hash_value *= 0x100000000;
+        hash_value = hash_value + (*word).into();
+    };
 
     hash_value
 }

--- a/packages/utils/src/hash.cairo
+++ b/packages/utils/src/hash.cairo
@@ -10,8 +10,47 @@ pub fn sha256_byte_array(byte: @ByteArray) -> ByteArray {
     hash_value
 }
 
+pub fn sha256_u256(hash: [u32; 8]) -> u256 {
+    let mut bytes = "";
+    for word in hash.span() {
+        bytes.append_word((*word).into(), 4);
+    };
+
+    let msg_hash = compute_sha256_byte_array(@bytes);
+    let mut hash_value: u256 = 0;
+    for word in msg_hash
+        .span() {
+            hash_value *= 0x100000000;
+            hash_value = hash_value + (*word).into();
+        };
+
+    hash_value
+}
+
 pub fn double_sha256_bytearray(byte: @ByteArray) -> ByteArray {
     return sha256_byte_array(@sha256_byte_array(byte));
+}
+
+pub fn hash_to_u256(hash: [u32; 8]) -> u256 {
+    let mut hash_value: u256 = 0;
+    for word in hash.span() {
+        hash_value *= 0x100000000;
+        hash_value = hash_value + (*word).into();
+    };
+
+    hash_value
+}
+
+pub fn simple_sha256(byte: @ByteArray) -> u256 {
+    let msg_hash = compute_sha256_byte_array(byte);
+    let mut hash_value: u256 = 0;
+    for word in msg_hash
+        .span() {
+            hash_value *= 0x100000000;
+            hash_value = hash_value + (*word).into();
+        };
+
+    hash_value
 }
 
 pub fn double_sha256(byte: @ByteArray) -> u256 {


### PR DESCRIPTION
<!-- enter the gh issue after hash -->
- [x] resolves ImplTaprootSigVerifier with hashcache
- [x] resolves Impl calc_taproot_signature_hash()
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/shinigami/blob/main/CONTRIBUTING.md)
- [x] resolves TxSigHashes handles segwite and taproot (SigHashMidstateTrait) but needs cache to complete functions 
calc_hash_inputs_amount and calc_hash_input_scripts in SigHashMidstateTrait::new(tx) for taproot
- [ ] code change includes tests



<!-- PR description below -->
I think it's essential to set up the cache in order to be able to retrieve the utxos of the inputs processed in the calcHashInputAmounts and calcHashInputScript functions. 
https://github.com/btcsuite/btcd/blob/master/txscript/hashcache.go#L157
Before going any further, I'd like your opinion
